### PR TITLE
Fix ImageContent error in non-3D FreeCAD views

### DIFF
--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -222,6 +222,35 @@ class FreeCADRPC:
         return get_parts_list()
 
     def get_active_screenshot(self, view_name: str = "Isometric") -> str:
+        """Get a screenshot of the active view.
+        
+        Returns a base64-encoded string of the screenshot or None if a screenshot
+        cannot be captured (e.g., when in TechDraw or Spreadsheet view).
+        """
+        # First check if the active view supports screenshots
+        def check_view_supports_screenshots():
+            try:
+                active_view = FreeCADGui.ActiveDocument.ActiveView
+                if active_view is None:
+                    FreeCAD.Console.PrintWarning("No active view available\n")
+                    return False
+                
+                view_type = type(active_view).__name__
+                has_save_image = hasattr(active_view, 'saveImage')
+                FreeCAD.Console.PrintMessage(f"View type: {view_type}, Has saveImage: {has_save_image}\n")
+                return has_save_image
+            except Exception as e:
+                FreeCAD.Console.PrintError(f"Error checking view capabilities: {e}\n")
+                return False
+                
+        rpc_request_queue.put(check_view_supports_screenshots)
+        supports_screenshots = rpc_response_queue.get()
+        
+        if not supports_screenshots:
+            FreeCAD.Console.PrintWarning("Current view does not support screenshots\n")
+            return None
+            
+        # If view supports screenshots, proceed with capture
         fd, tmp_path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
         rpc_request_queue.put(
@@ -240,6 +269,7 @@ class FreeCADRPC:
         else:
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
+            FreeCAD.Console.PrintWarning(f"Failed to capture screenshot: {res}\n")
             return None
 
     def _create_document_gui(self, name):
@@ -367,6 +397,10 @@ class FreeCADRPC:
     def _save_active_screenshot(self, save_path: str, view_name: str = "Isometric"):
         try:
             view = FreeCADGui.ActiveDocument.ActiveView
+            # Check if the view supports screenshots
+            if not hasattr(view, 'saveImage'):
+                return "Current view does not support screenshots"
+                
             if view_name == "Isometric":
                 view.viewIsometric()
             elif view_name == "Front":


### PR DESCRIPTION
I was extremely excited to discover this MCP server, thank you for creating it!  I have noticed that when viewing specialized FreeCAD views such as TechDraw or Spreadsheet, the MCP server was failing with a validation error due to the RPC server returning None for screenshots in these views.

Changes:
- Enhanced get_active_screenshot() to detect views without screenshot support
- Added preliminary check for saveImage method availability
- Improved error handling to return None gracefully when screenshots can't be captured
- Updated _save_active_screenshot() to validate view capabilities before proceeding


I have validated the suggested fix solves the problem in dev mode and ensures the MCP server works correctly in all FreeCAD view types without validation errors, maintaining compatibility with text-only mode and providing proper handling of specialized views.

You may see the validation chat here https://claude.ai/share/30437f59-db30-495a-ac7e-6de023f66c4d (last message in the chat was with the new RPC server but not in dev mode) 

This pull request suggests a fix to issue #8 