### PR TITLE
chore: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://claude.ai/share/7b48fd60-68ba-46fb-bb21-2fbb17399b48
 
 FreeCAD Addon directory is
 * Windows: `%APPDATA%\FreeCAD\Mod\`
-* Mac: `~/Library/Application Support/FreeCAD/Mod/`
+* Mac: `~/Library/Application\ Support/FreeCAD/Mod/`
 * Linux:
   * Ubuntu: `~/.FreeCAD/Mod/` or `~/snap/freecad/common/Mod/` (if you install FreeCAD from snap)
   * Debian: `~/.local/share/FreeCAD/Mod`


### PR DESCRIPTION
when running `cd ~/Library/Application Support` on my Mac I ran running into an error because of the empty space. This solves it by escaping the white space.