### PR TITLE
Add basic LLM + MCP integration examples for Google ADK and LangChain ReAct agents

### DIFF
--- a/examples/adk/.env
+++ b/examples/adk/.env
@@ -1,0 +1,1 @@
+GOOGLE_API_KEY=xxxx

--- a/examples/adk/__init__.py
+++ b/examples/adk/__init__.py
@@ -1,0 +1,1 @@
+from .import agent

--- a/examples/adk/agent.py
+++ b/examples/adk/agent.py
@@ -1,0 +1,25 @@
+from google.adk.agents.llm_agent import LlmAgent
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
+
+# Agent configuration
+AGENT_NAME = "cad_design_agent"
+MODEL_NAME = "gemini-2.5-flash-lite"
+FREECAD_MCP_DIR = "path/to/freecad-mcp"  # Replace with actual path
+
+# Basic instruction
+BASIC_PROMPT = "You are a CAD designer."
+
+# Initialize agent
+root_agent = LlmAgent(
+    model=MODEL_NAME,
+    name=AGENT_NAME,
+    instruction=BASIC_PROMPT,
+    tools=[
+        MCPToolset(
+            connection_params=StdioServerParameters(
+                command="uv",
+                args=["--directory", FREECAD_MCP_DIR, "run", "freecad-mcp"]
+            )
+        )
+    ]
+)

--- a/examples/langchain/react.py
+++ b/examples/langchain/react.py
@@ -1,0 +1,68 @@
+import os
+import logging
+import asyncio
+from langchain_groq import ChatGroq
+from mcp import ClientSession, StdioServerParameters
+from langchain_mcp_adapters.tools import load_mcp_tools
+from langgraph.prebuilt import create_react_agent
+from langchain_core.messages import SystemMessage, HumanMessage
+from mcp.client.stdio import stdio_client
+
+# Setup logging and environment
+logging.basicConfig(level=logging.INFO)
+
+
+# Initialize LLM
+llm = ChatGroq(
+    model="llama-3.1-8b-instant",
+    temperature=0.7,
+    name="cad_design_agent"
+)
+
+# MCP server parameters
+server_params = StdioServerParameters(
+    command="uv",
+    args=["--directory", "path/to/freecad-mcp", "run", "freecad-mcp"]
+)
+
+# Basic CAD assistant prompt
+INSTRUCTION = "You are a CAD designer."
+
+async def main():
+    if "GROQ_API_KEY" not in os.environ:
+        logging.error("GROQ_API_KEY is missing.")
+        return
+
+    logging.info("Starting MCP client...")
+    async with stdio_client(server_params) as (read, write):
+        logging.info("Connected to MCP server.")
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = await load_mcp_tools(session)
+
+            agent = create_react_agent(llm, tools)
+
+            print("\n Ready! Type 'exit' to quit.\n")
+            while True:
+                user_input = input("You: ").strip()
+                if user_input.lower() in ("exit", "quit"):
+                    print("Goodbye!")
+                    break
+
+                messages = [
+                    SystemMessage(content=INSTRUCTION),
+                    HumanMessage(content=user_input)
+                ]
+                try:
+                    response = await agent.ainvoke({"messages": messages})
+                    ai_msgs = response.get("messages", [])
+                    if ai_msgs:
+                        print(f"\n{ai_msgs[-1].content}\n")
+                    else:
+                        print("No response from agent.")
+                except Exception as e:
+                    logging.error(f"Agent error: {e}")
+                    print("Something went wrong.")
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This PR adds minimal, headless examples for setting up and running CAD design agents using:
- Google ADK with LlmAgent and MCPToolset
- LangChain ReAct agent integrated with MCP via stdio

**Key features:**
- Uses Groq LLM (llama-3.1-8b-instant) for CAD assistant tasks
- Demonstrates how to connect to FreeCAD MCP in a lightweight, headless environment
- Includes clear instructions and basic prompts tailored for CAD design workflows

These examples serve as a starting point for building custom CAD automation agents.