### PR TITLE
Add width/height parameters to get_view for custom screenshot resolution

### DIFF
--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -221,7 +221,7 @@ class FreeCADRPC:
     def get_parts_list(self):
         return get_parts_list()
 
-    def get_active_screenshot(self, view_name: str = "Isometric") -> str:
+    def get_active_screenshot(self, view_name: str = "Isometric", width: int | None = None, height: int | None = None) -> str:
         """Get a screenshot of the active view.
         
         Returns a base64-encoded string of the screenshot or None if a screenshot
@@ -254,7 +254,7 @@ class FreeCADRPC:
         fd, tmp_path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
         rpc_request_queue.put(
-            lambda: self._save_active_screenshot(tmp_path, view_name)
+            lambda: self._save_active_screenshot(tmp_path, view_name, width, height)
         )
         res = rpc_response_queue.get()
         if res is True:
@@ -394,7 +394,7 @@ class FreeCADRPC:
         except Exception as e:
             return str(e)
 
-    def _save_active_screenshot(self, save_path: str, view_name: str = "Isometric"):
+    def _save_active_screenshot(self, save_path: str, view_name: str = "Isometric", width: int | None = None, height: int | None = None):
         try:
             view = FreeCADGui.ActiveDocument.ActiveView
             # Check if the view supports screenshots
@@ -422,7 +422,10 @@ class FreeCADRPC:
             else:
                 raise ValueError(f"Invalid view name: {view_name}")
             view.fitAll()
-            view.saveImage(save_path, 1)
+            if width is not None and height is not None:
+                view.saveImage(save_path, width, height)
+            else:
+                view.saveImage(save_path)
             return True
         except Exception as e:
             return str(e)

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -42,7 +42,7 @@ class FreeCADConnection:
     def execute_code(self, code: str) -> dict[str, Any]:
         return self.server.execute_code(code)
 
-    def get_active_screenshot(self, view_name: str = "Isometric") -> str | None:
+    def get_active_screenshot(self, view_name: str = "Isometric", width: int | None = None, height: int | None = None) -> str | None:
         try:
             # Check if we're in a view that supports screenshots
             result = self.server.execute_code("""
@@ -72,7 +72,7 @@ else:
                 return None
 
             # Otherwise, try to get the screenshot
-            return self.server.get_active_screenshot(view_name)
+            return self.server.get_active_screenshot(view_name, width, height)
         except Exception as e:
             # Log the error but return None instead of raising an exception
             logger.error(f"Error getting screenshot: {e}")
@@ -436,7 +436,7 @@ def execute_code(ctx: Context, code: str) -> list[TextContent | ImageContent]:
 
 
 @mcp.tool()
-def get_view(ctx: Context, view_name: Literal["Isometric", "Front", "Top", "Right", "Back", "Left", "Bottom", "Dimetric", "Trimetric"]) -> list[ImageContent | TextContent]:
+def get_view(ctx: Context, view_name: Literal["Isometric", "Front", "Top", "Right", "Back", "Left", "Bottom", "Dimetric", "Trimetric"], width: int | None = None, height: int | None = None) -> list[ImageContent | TextContent]:
     """Get a screenshot of the active view.
 
     Args:
@@ -451,12 +451,14 @@ def get_view(ctx: Context, view_name: Literal["Isometric", "Front", "Top", "Righ
         - "Bottom"
         - "Dimetric"
         - "Trimetric"
+        width: The width of the screenshot in pixels. If not specified, uses the viewport width.
+        height: The height of the screenshot in pixels. If not specified, uses the viewport height.
 
     Returns:
         A screenshot of the active view.
     """
     freecad = get_freecad_connection()
-    screenshot = freecad.get_active_screenshot(view_name)
+    screenshot = freecad.get_active_screenshot(view_name, width, height)
     
     if screenshot is not None:
         return [ImageContent(type="image", data=screenshot, mimeType="image/png")]


### PR DESCRIPTION
## Summary
Add optional `width` and `height` parameters to the `get_view` tool to capture screenshots at custom resolutions.

## Changes
- Added `width` and `height` parameters to `get_view` MCP tool
- Parameters flow through `FreeCADConnection.get_active_screenshot` to RPC server
- When not specified, uses viewport's native resolution (existing behavior)

## Motivation

When validating FreeCAD models against specifications, screenshots consume significant context tokens.

**Sub-agents help but aren't sufficient:**
- A dedicated `freecad-analyze` sub-agent isolates screenshots from the main conversation
- However, the sub-agent itself has limited context
- Full-resolution screenshots still fill up the sub-agent's context quickly
- This limits the number of views/angles that can be analyzed in one session

**Resolution control solves this:**
- Smaller images = fewer tokens per screenshot
- More analysis iterations possible within the sub-agent's context
- Balance image quality vs. token budget based on the task
- Enables thorough multi-view analysis without context exhaustion

## Use Case

A `freecad-analyze` sub-agent that:
1. Runs in isolated context (screenshots stay there, not in main conversation)
2. Uses controlled resolution (e.g., 640x640) to limit token consumption
3. Can analyze multiple views/objects without exhausting context
4. Returns only a concise text report of anomalies

## Test plan
- Tested with explicit resolution (e.g., 400x300) - images render at correct size
- Tested without parameters - uses viewport resolution as before