### PR TITLE
Add focus_object parameter to get_view for centering view on specific object

### DIFF
--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -221,7 +221,7 @@ class FreeCADRPC:
     def get_parts_list(self):
         return get_parts_list()
 
-    def get_active_screenshot(self, view_name: str = "Isometric", width: int | None = None, height: int | None = None) -> str:
+    def get_active_screenshot(self, view_name: str = "Isometric", width: int | None = None, height: int | None = None, focus_object: str | None = None) -> str:
         """Get a screenshot of the active view.
         
         Returns a base64-encoded string of the screenshot or None if a screenshot
@@ -254,7 +254,7 @@ class FreeCADRPC:
         fd, tmp_path = tempfile.mkstemp(suffix=".png")
         os.close(fd)
         rpc_request_queue.put(
-            lambda: self._save_active_screenshot(tmp_path, view_name, width, height)
+            lambda: self._save_active_screenshot(tmp_path, view_name, width, height, focus_object)
         )
         res = rpc_response_queue.get()
         if res is True:
@@ -394,7 +394,7 @@ class FreeCADRPC:
         except Exception as e:
             return str(e)
 
-    def _save_active_screenshot(self, save_path: str, view_name: str = "Isometric", width: int | None = None, height: int | None = None):
+    def _save_active_screenshot(self, save_path: str, view_name: str = "Isometric", width: int | None = None, height: int | None = None, focus_object: str | None = None):
         try:
             view = FreeCADGui.ActiveDocument.ActiveView
             # Check if the view supports screenshots
@@ -421,7 +421,19 @@ class FreeCADRPC:
                 view.viewTrimetric()
             else:
                 raise ValueError(f"Invalid view name: {view_name}")
-            view.fitAll()
+
+            # Focus on specific object or fit all
+            if focus_object:
+                doc = FreeCAD.ActiveDocument
+                obj = doc.getObject(focus_object) if doc else None
+                if obj:
+                    FreeCADGui.Selection.clearSelection()
+                    FreeCADGui.Selection.addSelection(obj)
+                    FreeCADGui.SendMsgToActiveView("ViewSelection")
+                else:
+                    view.fitAll()
+            else:
+                view.fitAll()
             if width is not None and height is not None:
                 view.saveImage(save_path, width, height)
             else:

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -42,7 +42,7 @@ class FreeCADConnection:
     def execute_code(self, code: str) -> dict[str, Any]:
         return self.server.execute_code(code)
 
-    def get_active_screenshot(self, view_name: str = "Isometric", width: int | None = None, height: int | None = None) -> str | None:
+    def get_active_screenshot(self, view_name: str = "Isometric", width: int | None = None, height: int | None = None, focus_object: str | None = None) -> str | None:
         try:
             # Check if we're in a view that supports screenshots
             result = self.server.execute_code("""
@@ -72,7 +72,7 @@ else:
                 return None
 
             # Otherwise, try to get the screenshot
-            return self.server.get_active_screenshot(view_name, width, height)
+            return self.server.get_active_screenshot(view_name, width, height, focus_object)
         except Exception as e:
             # Log the error but return None instead of raising an exception
             logger.error(f"Error getting screenshot: {e}")
@@ -436,7 +436,7 @@ def execute_code(ctx: Context, code: str) -> list[TextContent | ImageContent]:
 
 
 @mcp.tool()
-def get_view(ctx: Context, view_name: Literal["Isometric", "Front", "Top", "Right", "Back", "Left", "Bottom", "Dimetric", "Trimetric"], width: int | None = None, height: int | None = None) -> list[ImageContent | TextContent]:
+def get_view(ctx: Context, view_name: Literal["Isometric", "Front", "Top", "Right", "Back", "Left", "Bottom", "Dimetric", "Trimetric"], width: int | None = None, height: int | None = None, focus_object: str | None = None) -> list[ImageContent | TextContent]:
     """Get a screenshot of the active view.
 
     Args:
@@ -453,12 +453,13 @@ def get_view(ctx: Context, view_name: Literal["Isometric", "Front", "Top", "Righ
         - "Trimetric"
         width: The width of the screenshot in pixels. If not specified, uses the viewport width.
         height: The height of the screenshot in pixels. If not specified, uses the viewport height.
+        focus_object: The name of the object to focus on. If not specified, fits all objects in the view.
 
     Returns:
         A screenshot of the active view.
     """
     freecad = get_freecad_connection()
-    screenshot = freecad.get_active_screenshot(view_name, width, height)
+    screenshot = freecad.get_active_screenshot(view_name, width, height, focus_object)
     
     if screenshot is not None:
         return [ImageContent(type="image", data=screenshot, mimeType="image/png")]


### PR DESCRIPTION
## Summary
Add optional `focus_object` parameter to center the view on a specific object by name.

> **Note**: This PR depends on #30 and should be merged after it.

## Changes
- Added `focus_object` parameter to `get_view` MCP tool
- Uses FreeCAD's Selection API to focus on the specified object
- Falls back to `fitAll()` if object not found or not specified

## Motivation

When validating models, a sub-agent needs to inspect specific objects in detail:

**Why focusing matters:**
- Full scene screenshots waste pixels on irrelevant objects
- Small objects get lost in wide shots, reducing anomaly detection accuracy
- Zooming to a specific object maximizes detail per token spent

**Combined with resolution control (#30):**
- Focus on object + controlled resolution = optimal detail-to-token ratio
- Enables precise visual verification of individual components
- Sub-agent can systematically inspect each object without context bloat

## Use Case

A `freecad-analyze` sub-agent that:
1. Calls `get_objects` first for dimensional data (cheap, no images)
2. For visual checks, uses `focus_object` to zoom in on the specific part
3. Captures at controlled resolution for token efficiency
4. Detects anomalies with higher accuracy due to focused view

## Test plan
- Tested focusing on different objects in a multi-object document
- Verified each object is centered in the resulting screenshot