### PR TITLE
Add list_documents tool to get open document names

### DIFF
--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -87,6 +87,9 @@ else:
     def get_parts_list(self) -> list[str]:
         return self.server.get_parts_list()
 
+    def list_documents(self) -> list[str]:
+        return self.server.list_documents()
+
 
 @asynccontextmanager
 async def server_lifespan(server: FastMCP) -> AsyncIterator[Dict[str, Any]]:
@@ -561,6 +564,18 @@ def get_parts_list(ctx: Context) -> list[TextContent]:
         return [
             TextContent(type="text", text=f"No parts found in the parts library. You must add parts_library addon.")
         ]
+
+
+@mcp.tool()
+def list_documents(ctx: Context) -> list[TextContent]:
+    """Get the list of open documents in FreeCAD.
+
+    Returns:
+        A list of document names.
+    """
+    freecad = get_freecad_connection()
+    docs = freecad.list_documents()
+    return [TextContent(type="text", text=json.dumps(docs))]
 
 
 @mcp.prompt()


### PR DESCRIPTION
## Summary
Add new `list_documents` MCP tool to retrieve the names of all open documents in FreeCAD.

## Changes
- Added `list_documents` method to `FreeCADConnection` class
- Added `list_documents` MCP tool handler
- Returns JSON array of document names

## Motivation

When a sub-agent starts, it needs to discover the current FreeCAD state:

**The problem:**
- `get_objects` requires a document name
- Without `list_documents`, the agent has no way to discover available documents
- Guessing document names wastes tokens on failed attempts

**The solution:**
- `list_documents` → `get_objects` → targeted `get_view` calls
- Cheap text-based discovery before any expensive screenshot calls
- Enables fully autonomous sub-agent workflow

## Use Case

A `freecad-analyze` sub-agent workflow:
1. `list_documents` - discover what's open (cheap, text only)
2. `get_objects` - get dimensional data (cheap, text only)
3. `get_view` with `focus_object` - only if visual verification needed

This prioritizes cheap operations before expensive ones.

## Test plan
- Tested with document open - returns `["DocumentName"]`
- The underlying RPC method already existed in `rpc_server.py`