### PR TITLE
QoL updates for gui. added defaults for startup

### DIFF
--- a/addon/FreeCADMCP/InitGui.py
+++ b/addon/FreeCADMCP/InitGui.py
@@ -6,10 +6,12 @@ class FreeCADMCPAddonWorkbench(Workbench):
         from rpc_server import rpc_server
 
         commands = [
-            "Start_RPC_Server",
-            "Stop_RPC_Server",
+            "Toggle_RPC_Server",
+            "Separator",
             "Toggle_Remote_Connections",
             "Configure_Allowed_IPs",
+            "Separator",
+            "Startup_Settings",
         ]
         self.appendToolbar("FreeCAD MCP", commands)
         self.appendMenu("FreeCAD MCP", commands)

--- a/addon/FreeCADMCP/rpc_server/serialize.py
+++ b/addon/FreeCADMCP/rpc_server/serialize.py
@@ -1,5 +1,4 @@
 import FreeCAD as App
-import json
 
 
 def serialize_value(value):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -66,7 +66,7 @@ wheels = [
 
 [[package]]
 name = "freecad-mcp"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
Changed the GUI around a bit. 
For the Start/Stop Sever: added a status indicator and made the buttons swap and show the action. 
For the remote access, change it to enable/disable remote access
Added a new startup settings for the user to define persistent state


<img width="565" height="146" alt="image" src="https://github.com/user-attachments/assets/4e6de17f-8761-46d7-947f-5d7facc7cf28" />
<img width="565" height="146" alt="image" src="https://github.com/user-attachments/assets/c9befd2d-5215-48bc-bf4c-2684a8197e30" />
<img width="641" height="274" alt="image" src="https://github.com/user-attachments/assets/cf5b289d-504a-43a8-99c8-2cc937538719" />
<img width="516" height="449" alt="image" src="https://github.com/user-attachments/assets/bc650ab0-1411-4536-ba5a-778bea74acb8" />
