### PR TITLE
feat: add auto-start option for RPC server

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ And you can start RPC server by "Start RPC Server" command in "FreeCAD MCP" tool
 
 ![start_rpc_server](./assets/start_rpc_server.png)
 
+### Auto-Start RPC Server
+
+By default, the RPC server must be started manually each time FreeCAD opens. To start it automatically:
+
+1. Open the **FreeCAD MCP** menu (switch to the MCP Addon workbench first)
+2. Check **Auto-Start Server**
+
+The setting is saved to `freecad_mcp_settings.json` and persists across sessions. On the next FreeCAD launch, the RPC server will start automatically once the application finishes loading.
+
+You can disable it at any time by unchecking **Auto-Start Server** in the same menu.
+
 ## Setting up Claude Desktop
 
 Pre-installation of the [uvx](https://docs.astral.sh/uv/guides/tools/) is required.

--- a/addon/FreeCADMCP/InitGui.py
+++ b/addon/FreeCADMCP/InitGui.py
@@ -8,6 +8,7 @@ class FreeCADMCPAddonWorkbench(Workbench):
         commands = [
             "Start_RPC_Server",
             "Stop_RPC_Server",
+            "Toggle_Auto_Start",
             "Toggle_Remote_Connections",
             "Configure_Allowed_IPs",
         ]
@@ -28,3 +29,22 @@ class FreeCADMCPAddonWorkbench(Workbench):
 
 
 Gui.addWorkbench(FreeCADMCPAddonWorkbench())
+
+
+def _auto_start_mcp():
+    try:
+        from rpc_server import rpc_server
+
+        settings = rpc_server.load_settings()
+        if not settings.get("auto_start_rpc", False):
+            return
+
+        msg = rpc_server.start_rpc_server()
+        FreeCAD.Console.PrintMessage(f"[MCP] Auto-start: {msg}\n")
+    except Exception as e:
+        FreeCAD.Console.PrintWarning(f"[MCP] Auto-start failed: {e}\n")
+
+
+from PySide import QtCore
+
+QtCore.QTimer.singleShot(0, _auto_start_mcp)

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -32,6 +32,7 @@ _SETTINGS_FILENAME = "freecad_mcp_settings.json"
 _DEFAULT_SETTINGS = {
     "remote_enabled": False,
     "allowed_ips": "127.0.0.1",
+    "auto_start_rpc": False,
 }
 
 
@@ -709,26 +710,59 @@ class ConfigureAllowedIPsCommand:
         return True
 
 
+class ToggleAutoStartCommand:
+    def GetResources(self):
+        return {
+            "MenuText": "Auto-Start Server",
+            "ToolTip": "Automatically start the RPC server when FreeCAD launches.",
+            "Checkable": True,
+        }
+
+    def Activated(self, checked=0):
+        settings = load_settings()
+        settings["auto_start_rpc"] = bool(checked)
+        save_settings(settings)
+
+        if settings["auto_start_rpc"]:
+            FreeCAD.Console.PrintMessage(
+                "MCP RPC server will start automatically on next FreeCAD launch.\n"
+            )
+        else:
+            FreeCAD.Console.PrintMessage(
+                "MCP RPC server auto-start disabled.\n"
+            )
+
+    def IsActive(self):
+        return True
+
+
 FreeCADGui.addCommand("Start_RPC_Server", StartRPCServerCommand())
 FreeCADGui.addCommand("Stop_RPC_Server", StopRPCServerCommand())
+FreeCADGui.addCommand("Toggle_Auto_Start", ToggleAutoStartCommand())
 FreeCADGui.addCommand("Toggle_Remote_Connections", ToggleRemoteConnectionsCommand())
 FreeCADGui.addCommand("Configure_Allowed_IPs", ConfigureAllowedIPsCommand())
 
 
-def _sync_remote_toggle_state():
-    """Sync the Remote Connections checkbox with saved settings on startup."""
+def _sync_toggle_states():
+    """Sync checkable menu items with saved settings on startup."""
     try:
         settings = load_settings()
-        enabled = settings.get("remote_enabled", False)
         main_window = FreeCADGui.getMainWindow()
+        toggle_map = {
+            "Remote Connections": settings.get("remote_enabled", False),
+            "Auto-Start Server": settings.get("auto_start_rpc", False),
+        }
+        found = 0
         for action in main_window.findChildren(QtWidgets.QAction):
-            if action.text() == "Remote Connections":
-                action.setChecked(enabled)
-                return
+            if action.text() in toggle_map:
+                action.setChecked(toggle_map[action.text()])
+                found += 1
+                if found == len(toggle_map):
+                    return
     except Exception:
         pass
     # Retry if menu not ready yet
-    QtCore.QTimer.singleShot(2000, _sync_remote_toggle_state)
+    QtCore.QTimer.singleShot(2000, _sync_toggle_states)
 
 
-QtCore.QTimer.singleShot(2000, _sync_remote_toggle_state)
+QtCore.QTimer.singleShot(2000, _sync_toggle_states)


### PR DESCRIPTION
## Summary

<img width="558" height="166" alt="Screenshot 2026-03-16 at 15 28 23" src="https://github.com/user-attachments/assets/97b0bf26-e913-46b3-95af-b903c09f65d2" />

- Adds an opt-in `auto_start_rpc` setting so the RPC server starts automatically when FreeCAD launches
- New **"Auto-Start Server"** checkable menu item under the FreeCAD MCP menu for easy toggling
- Uses `QTimer.singleShot(0, ...)` in `InitGui.py` to defer startup until FreeCAD's event loop is ready
- Default is `false` — no behavior change for existing users

## Motivation

Currently users must manually click "Start RPC Server" every time FreeCAD opens before the MCP bridge can connect. This adds friction, especially for users who always want the server running.

## Changes

| File | Change |
|------|--------|
| `rpc_server.py` | Added `auto_start_rpc: false` to `_DEFAULT_SETTINGS` |
| `rpc_server.py` | New `ToggleAutoStartCommand` (checkable menu item, same pattern as `ToggleRemoteConnectionsCommand`) |
| `rpc_server.py` | Consolidated `_sync_remote_toggle_state` → `_sync_toggle_states` to sync both checkboxes |
| `InitGui.py` | Added `_auto_start_mcp()` with `QTimer.singleShot(0, ...)` that checks the setting before starting |
| `InitGui.py` | Added `Toggle_Auto_Start` to workbench commands list |

## Design decisions

- **`singleShot(0)` instead of arbitrary delay**: A 0ms timer queues execution for the next event loop iteration (after all `InitGui.py` files finish loading), rather than guessing a delay like 2000ms
- **Opt-in by default**: `auto_start_rpc` defaults to `false` so existing users are unaffected
- **Settings-driven**: Uses the existing `freecad_mcp_settings.json` persistence system — `load_settings()` automatically merges new default keys into existing settings files
- **Cross-platform**: Only uses `PySide.QtCore.QTimer` and `FreeCAD.getUserAppDataDir()` — no OS-specific code


🤖 Generated with [Claude Code](https://claude.com/claude-code)