### PR TITLE
fix: preserve traceback in langchain react example

### DIFF
--- a/examples/langchain/react.py
+++ b/examples/langchain/react.py
@@ -60,8 +60,8 @@ async def main():
                         print(f"\n{ai_msgs[-1].content}\n")
                     else:
                         print("No response from agent.")
-                except Exception as e:
-                    logging.error(f"Agent error: {e}")
+                except Exception:
+                    logging.exception("Agent error")
                     print("Something went wrong.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
The REACT example was catching every exception from agent execution and only logging the exception string before continuing. This change keeps the existing user-facing fallback but logs the full traceback so upstream and parsing failures remain diagnosable.
## Why it matters
Without the traceback, distinct failures such as transport errors or unexpected response-shape errors collapse into the same generic message and are hard to debug in production. Operators only see "Something went wrong." and lose the stack context needed to identify the real fault.
## Testing
Verified by inspection that the success path is unchanged and only the exception-reporting branch differs. Local automated tests were not run here because the target repository is not present in this workspace.