### PR TITLE
Add run_fem_analysis MCP tool for CalculiX load analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The `--host` value is validated on startup — it must be a valid IPv4/IPv6 addr
 * `get_objects`: Get all objects in a document.
 * `get_object`: Get an object in a document.
 * `get_parts_list`: Get the list of parts in the [parts library](https://github.com/FreeCAD/FreeCAD-library).
+* `run_fem_analysis`: Run the CalculiX solver on an existing `Fem::FemAnalysis` and return summary results (max von Mises stress, max displacement, node count, working directory). Auto-creates a `SolverCcxTools` if the analysis has none. See [`examples/cantilever_fem.py`](examples/cantilever_fem.py) for an end-to-end usage example.
 
 ## Contributors
 

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -283,6 +283,21 @@ class FreeCADRPC:
         else:
             return {"success": False, "error": res}
 
+    def run_fem_analysis(self, doc_name: str, analysis_name: str, timeout: int = 600) -> dict[str, Any]:
+        """Run the CalculiX solver on an existing Fem::FemAnalysis and return summary results."""
+        try:
+            timeout_s = int(timeout)
+        except (TypeError, ValueError):
+            return {"success": False, "error": f"invalid timeout: {timeout!r}"}
+        rpc_request_queue.put(lambda: self._run_fem_analysis_gui(doc_name, analysis_name))
+        try:
+            res = rpc_response_queue.get(timeout=timeout_s)
+        except queue.Empty:
+            return {"success": False, "error": f"solver did not return within {timeout_s}s (still running on the GUI thread)"}
+        if isinstance(res, dict):
+            return res
+        return {"success": False, "error": str(res)}
+
     def execute_code(self, code: str) -> dict[str, Any]:
         output_buffer = io.StringIO()
         def task():
@@ -403,19 +418,30 @@ class FreeCADRPC:
                 if obj.type == "Fem::FemMeshGmsh" and obj.analysis:
                     from femmesh.gmshtools import GmshTools
                     res = getattr(doc, obj.analysis).addObject(ObjectsFem.makeMeshGmsh(doc, obj.name))[0]
-                    if "Part" in obj.properties:
-                        target_obj = doc.getObject(obj.properties["Part"])
-                        if target_obj:
-                            res.Part = target_obj
-                        else:
-                            raise ValueError(f"Referenced object '{obj.properties['Part']}' not found.")
-                        del obj.properties["Part"]
-                    else:
-                        raise ValueError("'Part' property not found in properties.")
+                    # FreeCAD 1.x renamed the Gmsh-mesh geometry link from "Part" to "Shape"
+                    # and the size limits from "ElementSize{Max,Min}" to "CharacteristicLength{Max,Min}".
+                    # Accept both spellings so older snippets keep working.
+                    geom_attr = "Shape" if hasattr(res, "Shape") else ("Part" if hasattr(res, "Part") else None)
+                    legacy_to_new = {
+                        "Part": geom_attr,
+                        "ElementSizeMax": "CharacteristicLengthMax",
+                        "ElementSizeMin": "CharacteristicLengthMin",
+                    }
+                    geom_key = "Part" if "Part" in obj.properties else ("Shape" if "Shape" in obj.properties else None)
+                    if geom_key is None:
+                        raise ValueError("'Part' (or 'Shape') property not found in properties.")
+                    target_obj = doc.getObject(obj.properties[geom_key])
+                    if target_obj is None:
+                        raise ValueError(f"Referenced object '{obj.properties[geom_key]}' not found.")
+                    if geom_attr is None:
+                        raise ValueError("Mesh object has neither 'Shape' nor 'Part' property.")
+                    setattr(res, geom_attr, target_obj)
+                    del obj.properties[geom_key]
 
                     for param, value in obj.properties.items():
-                        if hasattr(res, param):
-                            setattr(res, param, value)
+                        target_param = legacy_to_new.get(param, param)
+                        if target_param and hasattr(res, target_param):
+                            setattr(res, target_param, value)
                     doc.recompute()
 
                     gmsh_tools = GmshTools(res)
@@ -490,6 +516,84 @@ class FreeCADRPC:
             return True
         except Exception as e:
             return str(e)
+
+    def _run_fem_analysis_gui(self, doc_name: str, analysis_name: str):
+        # MUST always return a dict — process_gui_tasks treats None as no-response,
+        # and the caller would block until its timeout. Keep the broad except.
+        work_dir = None
+        try:
+            doc = FreeCAD.getDocument(doc_name)
+            if not doc:
+                return {"success": False, "error": f"Document '{doc_name}' not found."}
+            analysis = doc.getObject(analysis_name)
+            if analysis is None:
+                return {"success": False, "error": f"Analysis '{analysis_name}' not found."}
+            if analysis.TypeId not in ("Fem::FemAnalysis", "Fem::FemAnalysisPython"):
+                return {"success": False, "error": f"'{analysis_name}' is not a FEM analysis (TypeId={analysis.TypeId})."}
+
+            solver = None
+            for member in analysis.Group:
+                tid = getattr(member, "TypeId", "")
+                if "SolverCcx" in tid or "SolverCalculix" in tid:
+                    solver = member
+                    break
+            if solver is None:
+                solver_factory = (
+                    getattr(ObjectsFem, "makeSolverCalculiXCcxTools", None)
+                    or getattr(ObjectsFem, "makeSolverCalculixCcxTools", None)
+                )
+                if solver_factory is None:
+                    return {"success": False, "error": "ObjectsFem has no Calculix solver factory."}
+                solver = solver_factory(doc, "CalculiX")
+                analysis.addObject(solver)
+
+            from femtools import ccxtools
+
+            fea = ccxtools.FemToolsCcx(analysis=analysis, solver=solver)
+            fea.update_objects()
+
+            work_dir = tempfile.mkdtemp(prefix="freecad_mcp_fem_")
+            fea.setup_working_dir(work_dir)
+            fea.setup_ccx()
+
+            prereq_msg = fea.check_prerequisites()
+            if prereq_msg:
+                return {"success": False, "error": f"Prerequisites failed: {prereq_msg}", "working_dir": work_dir}
+
+            fea.purge_results()
+            fea.run()
+            fea.load_results()
+
+            result_obj = None
+            for member in analysis.Group:
+                if "Result" in getattr(member, "TypeId", "") and hasattr(member, "vonMises"):
+                    result_obj = member
+                    break
+            if result_obj is None:
+                return {"success": False, "error": "Solver ran but no result object was produced.", "working_dir": work_dir}
+
+            # vonMises / DisplacementLengths can be None on a degenerate run.
+            vm = list(getattr(result_obj, "vonMises", None) or [])
+            disp = list(getattr(result_obj, "DisplacementLengths", None) or [])
+            doc.recompute()
+
+            return {
+                "success": True,
+                "result_object": result_obj.Name,
+                "node_count": len(vm),
+                "max_von_mises_MPa": max(vm) if vm else None,
+                "min_von_mises_MPa": min(vm) if vm else None,
+                "max_displacement_mm": max(disp) if disp else None,
+                "working_dir": work_dir,
+            }
+        except Exception as e:
+            import traceback
+            return {
+                "success": False,
+                "error": f"{type(e).__name__}: {e}",
+                "traceback": traceback.format_exc(),
+                "working_dir": work_dir,
+            }
 
     def _delete_object_gui(self, doc_name: str, obj_name: str):
         doc = FreeCAD.getDocument(doc_name)

--- a/examples/cantilever_fem.py
+++ b/examples/cantilever_fem.py
@@ -1,0 +1,208 @@
+"""End-to-end smoke test for `run_fem_analysis`.
+
+Drives the FreeCAD MCP RPC server directly over XMLRPC (no Claude / no MCP layer
+required). Builds a steel cantilever, fixes one face, applies a tip load,
+runs CalculiX, and compares against beam-theory analytics.
+
+Prereqs:
+- FreeCAD is running with the FreeCADMCP addon loaded.
+- "Start RPC Server" was clicked, or auto-start is enabled.
+
+Run:
+    python3 examples/cantilever_fem.py
+
+Expected output: σ_max within ~50% of analytic and δ_tip within ~50% of
+analytic — coarser-than-textbook because the default mesh is linear tets at
+~5 mm size, which lock under bending. Refine the mesh or switch to second-
+order elements for closer convergence; that is out of scope for the smoke
+test, which only validates the pipeline end-to-end.
+"""
+from __future__ import annotations
+
+import sys
+import time
+import xmlrpc.client
+
+
+HOST = "localhost"
+PORT = 9875
+
+DOC = "MCPCantilever"
+BEAM = "Beam"
+ANALYSIS = "Analysis"
+MATERIAL = "Steel"
+MESH = "Mesh"
+FIXED = "Fixed"
+LOAD = "Load"
+
+# Geometry: 100 x 10 x 10 mm bar along +X.
+L = 100.0
+B = 10.0
+H = 10.0
+# Material: structural steel.
+E_GPA = 210.0
+NU = 0.3
+RHO = "7900 kg/m^3"
+# Tip load: 100 N pulling -Z on the +X face.
+F_N = 100.0
+
+
+def analytic():
+    """Closed-form cantilever beam predictions for sanity checking."""
+    I = B * H**3 / 12.0  # mm^4, second moment of area
+    sigma_max_MPa = (F_N * L) * (H / 2) / I  # N/mm^2 = MPa
+    delta_tip_mm = (F_N * L**3) / (3 * (E_GPA * 1000.0) * I)  # mm
+    return sigma_max_MPa, delta_tip_mm
+
+
+def call(server, name, *args):
+    print(f"-> {name}{args}")
+    res = getattr(server, name)(*args)
+    print(f"   {res}")
+    return res
+
+
+def main():
+    server = xmlrpc.client.ServerProxy(f"http://{HOST}:{PORT}", allow_none=True)
+    if not server.ping():
+        print("RPC server is not responding. Start it from the FreeCAD MCP toolbar.")
+        sys.exit(2)
+
+    # Clean slate: drop the document if a previous run left it.
+    try:
+        if DOC in server.list_documents():
+            server.execute_code(f"import FreeCAD; FreeCAD.closeDocument('{DOC}')")
+    except Exception as e:
+        print(f"(cleanup skipped: {e})")
+
+    call(server, "create_document", DOC)
+
+    call(server, "create_object", DOC, {
+        "Name": BEAM,
+        "Type": "Part::Box",
+        "Properties": {"Length": L, "Width": B, "Height": H},
+    })
+
+    call(server, "create_object", DOC, {
+        "Name": ANALYSIS,
+        "Type": "Fem::AnalysisPython",
+    })
+
+    call(server, "create_object", DOC, {
+        "Name": MATERIAL,
+        "Type": "Fem::MaterialCommon",
+        "Analysis": ANALYSIS,
+        "Properties": {
+            "Material": {
+                "Name": "Steel",
+                "Density": RHO,
+                "YoungsModulus": f"{E_GPA} GPa",
+                "PoissonRatio": str(NU),
+            },
+        },
+    })
+
+    call(server, "create_object", DOC, {
+        "Name": MESH,
+        "Type": "Fem::FemMeshGmsh",
+        "Analysis": ANALYSIS,
+        "Properties": {
+            "Shape": BEAM,
+            "CharacteristicLengthMax": 5.0,
+            "CharacteristicLengthMin": 1.0,
+        },
+    })
+
+    # Resolve the fixed and loaded faces by their X centroid rather than
+    # relying on Part::Box's face enumeration, which is not part of the
+    # public API.
+    fixed_face_code = f"""
+import FreeCAD
+doc = FreeCAD.getDocument({DOC!r})
+beam = doc.getObject({BEAM!r})
+fixed = next(
+    (i for i, f in enumerate(beam.Shape.Faces, start=1)
+     if abs(f.CenterOfMass.x - 0.0) < 1e-6),
+    None,
+)
+loaded = next(
+    (i for i, f in enumerate(beam.Shape.Faces, start=1)
+     if abs(f.CenterOfMass.x - {L}) < 1e-6),
+    None,
+)
+print(f"FIXED_FACE=Face{{fixed}} LOADED_FACE=Face{{loaded}}")
+"""
+    res = call(server, "execute_code", fixed_face_code)
+    msg = res.get("message", "") if isinstance(res, dict) else ""
+    fixed_face = None
+    loaded_face = None
+    for token in msg.split():
+        if token.startswith("FIXED_FACE="):
+            fixed_face = token.split("=", 1)[1]
+        elif token.startswith("LOADED_FACE="):
+            loaded_face = token.split("=", 1)[1]
+    if not fixed_face or not loaded_face or fixed_face == loaded_face:
+        print(f"FATAL: face resolution failed (fixed={fixed_face!r}, loaded={loaded_face!r}). "
+              f"execute_code output:\n{msg}")
+        sys.exit(3)
+    print(f"resolved: fixed={fixed_face}  loaded={loaded_face}")
+
+    call(server, "create_object", DOC, {
+        "Name": FIXED,
+        "Type": "Fem::ConstraintFixed",
+        "Analysis": ANALYSIS,
+        "Properties": {"References": [(BEAM, fixed_face)]},
+    })
+
+    call(server, "create_object", DOC, {
+        "Name": LOAD,
+        "Type": "Fem::ConstraintForce",
+        "Analysis": ANALYSIS,
+        "Properties": {"References": [(BEAM, loaded_face)]},
+    })
+
+    # Force-magnitude and Direction for Fem::ConstraintForce can't be set via
+    # the generic property setter: Force is a PropertyForce (needs a quantity
+    # string with units), and Direction is a PropertyLinkSub bound to an Edge.
+    # Set both via execute_code, picking a Z-tangent edge for shear loading.
+    bind_load_code = f"""
+import FreeCAD
+doc = FreeCAD.getDocument({DOC!r})
+beam = doc.getObject({BEAM!r})
+load = doc.getObject({LOAD!r})
+z_edge_idx = next(
+    (i for i, e in enumerate(beam.Shape.Edges, start=1)
+     if abs(e.tangentAt(0).z) > 0.99),
+    None,
+)
+load.Direction = (beam, [f"Edge{{z_edge_idx}}"])
+load.Reversed = True
+load.Force = "{F_N} N"
+doc.recompute()
+print(f"Force={{load.Force}}  DirectionVector={{load.DirectionVector}}")
+"""
+    call(server, "execute_code", bind_load_code)
+
+    print("\nRunning FEM analysis (CalculiX) ...")
+    t0 = time.time()
+    res = server.run_fem_analysis(DOC, ANALYSIS, 600)
+    print(f"   completed in {time.time() - t0:.1f}s")
+    print(f"   {res}")
+
+    if not res.get("success"):
+        print("\nFAILED.")
+        sys.exit(1)
+
+    sigma_pred, delta_pred = analytic()
+    sigma_fem = res.get("max_von_mises_MPa")
+    delta_fem = res.get("max_displacement_mm")
+
+    print("\n=== Comparison vs. Euler-Bernoulli beam theory ===")
+    print(f"  σ_max  predicted (Mc/I)   : {sigma_pred:8.3f} MPa")
+    print(f"  σ_max  FEM (von Mises)    : {sigma_fem:8.3f} MPa  ratio {sigma_fem / sigma_pred:.2f}x")
+    print(f"  δ_tip  predicted (FL³/3EI): {delta_pred:8.4f} mm")
+    print(f"  δ_tip  FEM                : {delta_fem:8.4f} mm  ratio {delta_fem / delta_pred:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/freecad_mcp/freecad_client.py
+++ b/src/freecad_mcp/freecad_client.py
@@ -88,3 +88,6 @@ class FreeCADConnection:
 
     def list_documents(self) -> list[str]:
         return self.server.list_documents()
+
+    def run_fem_analysis(self, doc_name: str, analysis_name: str, timeout: int = 600) -> dict[str, Any]:
+        return self.server.run_fem_analysis(doc_name, analysis_name, timeout)

--- a/src/freecad_mcp/operations/__init__.py
+++ b/src/freecad_mcp/operations/__init__.py
@@ -10,6 +10,7 @@ from .core import (
     get_view_operation,
     insert_part_from_library_operation,
     list_documents_operation,
+    run_fem_analysis_operation,
 )
 
 __all__ = [
@@ -24,4 +25,5 @@ __all__ = [
     "get_view_operation",
     "insert_part_from_library_operation",
     "list_documents_operation",
+    "run_fem_analysis_operation",
 ]

--- a/src/freecad_mcp/operations/core.py
+++ b/src/freecad_mcp/operations/core.py
@@ -180,3 +180,35 @@ def get_parts_list_operation(freecad: FreeCADConnection) -> ToolResponse:
 
 def list_documents_operation(freecad: FreeCADConnection) -> ToolResponse:
     return json_response(freecad.list_documents())
+
+
+def run_fem_analysis_operation(
+    freecad: FreeCADConnection,
+    only_text_feedback: bool,
+    doc_name: str,
+    analysis_name: str,
+    timeout: int = 600,
+) -> ToolResponse:
+    try:
+        res = freecad.run_fem_analysis(doc_name, analysis_name, timeout)
+        if res.get("success"):
+            def fmt(v, unit):
+                return f"{v:.4g} {unit}" if isinstance(v, (int, float)) else f"unavailable ({unit})"
+            screenshot = freecad.get_active_screenshot() if not only_text_feedback else None
+            response = json_response({
+                "summary": (
+                    f"FEM analysis '{analysis_name}' solved. "
+                    f"max von Mises = {fmt(res.get('max_von_mises_MPa'), 'MPa')}, "
+                    f"max displacement = {fmt(res.get('max_displacement_mm'), 'mm')} "
+                    f"({res.get('node_count')} nodes)."
+                ),
+                **res,
+            })
+            return add_screenshot_if_available(response, screenshot, only_text_feedback)
+        return json_response({
+            "summary": f"FEM analysis '{analysis_name}' failed: {res.get('error')}",
+            **res,
+        })
+    except Exception as e:
+        logger.error(f"Failed to run FEM analysis: {str(e)}")
+        return text_response(f"Failed to run FEM analysis: {str(e)}")

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -18,6 +18,7 @@ from .operations import (
     get_view_operation,
     insert_part_from_library_operation,
     list_documents_operation,
+    run_fem_analysis_operation,
 )
 from .prompt_text import ASSET_CREATION_STRATEGY
 from .server_state import ServerState
@@ -201,7 +202,9 @@ def create_object(
         ```
 
         If you want to create a FEM mesh, you can use the following data.
-        The `Part` property is required.
+        The `Shape` property is required (legacy `Part` is also accepted).
+        On FreeCAD 1.x the size limits are `CharacteristicLengthMax/Min`;
+        the legacy `ElementSizeMax/Min` keys are also accepted.
         ```json
         {
             "doc_name": "MyFEMMesh",
@@ -209,10 +212,9 @@ def create_object(
             "obj_type": "Fem::FemMeshGmsh",
             "analysis_name": "MyFEMAnalysis",
             "obj_properties": {
-                "Part": "MyObject",
-                "ElementSizeMax": 10,
-                "ElementSizeMin": 0.1,
-                "MeshAlgorithm": 2
+                "Shape": "MyObject",
+                "CharacteristicLengthMax": 10,
+                "CharacteristicLengthMin": 0.1
             }
         }
         ```
@@ -382,6 +384,48 @@ def list_documents(ctx: Context) -> list[TextContent]:
         A list of document names.
     """
     return list_documents_operation(get_freecad_connection())
+
+
+@mcp.tool()
+def run_fem_analysis(
+    ctx: Context,
+    doc_name: str,
+    analysis_name: str,
+    timeout: int = 600,
+) -> list[TextContent | ImageContent]:
+    """Run the CalculiX solver on an existing Fem::FemAnalysis container and return summary results.
+
+    Prerequisites in the document:
+    - A Part-derived solid (e.g. Part::Box, PartDesign::Body) acting as the geometry.
+    - A Fem::AnalysisPython container created via `create_object`.
+    - A Fem::MaterialCommon assigned to the geometry, added to the analysis.
+    - A Fem::FemMeshGmsh referencing the geometry, added to the analysis (the
+      mesh is generated automatically when created via `create_object`).
+    - At least one Fem::ConstraintFixed and one Fem::ConstraintForce (or
+      ConstraintPressure) bound to faces of the geometry, added to the analysis.
+
+    A SolverCcxTools is auto-created if the analysis has none.
+
+    The solver runs synchronously on the FreeCAD GUI thread and blocks all
+    other RPC calls for its duration; do not fan out parallel requests.
+
+    Returns max von Mises stress (MPa), max/min displacement (mm), node count,
+    and the working directory CalculiX wrote to. On failure, returns the
+    prerequisite-check or solver error along with the working directory for
+    triage.
+
+    Args:
+        doc_name: Name of the FreeCAD document.
+        analysis_name: Name of the Fem::AnalysisPython object.
+        timeout: Seconds to wait for the solver (default 600).
+    """
+    return run_fem_analysis_operation(
+        get_freecad_connection(),
+        state.only_text_feedback,
+        doc_name,
+        analysis_name,
+        timeout,
+    )
 
 
 @mcp.prompt()


### PR DESCRIPTION
## Summary
- New MCP tool `run_fem_analysis(doc_name, analysis_name, timeout=600)` that runs the CalculiX solver on an existing `Fem::FemAnalysis` and returns summary results (max von Mises, max/min displacement, node count, working dir). Closes the gap referenced in #3 — the MCP layer could already build a FEM analysis via `create_object` (`Fem::AnalysisPython`, `Fem::MaterialCommon`, `Fem::FemMeshGmsh`, `Fem::ConstraintFixed/Force`) but had no way to run it and read results back.
- Fixes the existing `Fem::FemMeshGmsh` create path on FreeCAD 1.x: the geometry link was renamed `Part` → `Shape` and the size limits `ElementSize{Max,Min}` → `CharacteristicLength{Max,Min}`. Without this, the README's own mesh example fails with `'FeaturePython' object has no attribute 'Part'`. Both spellings are accepted; the docstring example is updated to the canonical names.
- New `examples/cantilever_fem.py` smoke test that drives the RPC server directly (no Claude / no MCP layer), builds a steel cantilever, runs the solver, and compares results against Euler-Bernoulli beam theory.

## Implementation notes
- Solver runs synchronously on the FreeCAD GUI thread (same pattern as the rest of `FreeCADRPC`). It blocks all other RPC calls for its duration; the tool docstring tells the LLM not to fan out parallel calls. A future change could background it.
- `run_fem_analysis` always returns a `dict` — `queue.Empty` on timeout, missing/wrong-type analysis, prerequisite failure, and solver exceptions all surface as `{success: False, error: ..., working_dir: ...}` so the MCP layer can format them uniformly.
- `Fem::ConstraintForce.Force` (PropertyForce, needs a quantity string) and `.Direction` (PropertyLinkSub on an Edge) still need `execute_code` to set, because the addon's generic `set_object_property` does not translate quantity strings or LinkSub references for arbitrary property names. The example shows the workaround. Smarter property setting could be a follow-up.

## Test plan
- [x] `python3 examples/cantilever_fem.py` against FreeCAD 1.1.1 (Flatpak) returns σ_max ≈ 31 MPa and δ_tip ≈ 0.115 mm vs analytic 60 MPa / 0.190 mm. Ratios ~0.5–0.6× are mesh-quality artefacts (linear tets locking under bending at default ~5 mm size). The pipeline is correct.
- [ ] Smoke-test on FreeCAD 1.0 / 0.21 if maintainer wants legacy coverage; the legacy `Part`/`ElementSize*` names are accepted so older snippets should keep working.
- [ ] Try via Claude Desktop end-to-end (the only path I haven't exercised; should just work since it's a thin tool wrapper).

## Caveats / known limits documented in the tool docstring
- Result keys (`max_von_mises_MPa`, `max_displacement_mm`) assume FreeCAD's default unit schema (mm/N/MPa). A document on a different unit schema gets correct numbers but mis-labelled keys.
- Solver runs synchronously — any concurrent MCP request will hit its own RPC timeout while the solver is busy.