### PR TITLE
fix: bind RPC server to 127.0.0.1 instead of localhost

### DIFF
--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -759,7 +759,7 @@ def start_rpc_server(port=9875):
     if remote_enabled:
         host = "0.0.0.0"
     else:
-        host = "localhost"
+        host = "127.0.0.1"
 
     rpc_server_instance = FilteredXMLRPCServer(
         (host, port), allowed_ips_str=allowed_ips, allow_none=True, logRequests=False


### PR DESCRIPTION
On macOS, "localhost" resolves to IPv6 ::1 in Python's socketserver, but xmlrpc.client.ServerProxy resolves it to IPv4 127.0.0.1. This mismatch causes ConnectionRefusedError when the MCP client tries to connect to the FreeCAD RPC server.

Changing the default bind address to "127.0.0.1" ensures both sides consistently use IPv4 and connect successfully on all platforms. Users who need remote access can still set remote_enabled=True in settings (which uses "0.0.0.0").