### PR TITLE
Add reload_document tool for picking up external file changes

### DIFF
--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -86,6 +86,18 @@ class FreeCADRPC:
             return {"success": True, "object_name": obj_name}
         return _err(res)
 
+
+    def reload_document(self, doc_name: str) -> dict[str, Any]:
+        """Close and re-open a document by name to pick up external file
+        changes (e.g. edits made by another process such as `freecadcmd`
+        running headlessly). Returns success once the new document is
+        loaded from disk.
+        """
+        res = dispatch_to_gui(lambda: self._reload_document_gui(doc_name))
+        if _ok(res):
+            return {"success": True, "document_name": doc_name}
+        return _err(res)
+
     def run_fem_analysis(self, doc_name: str, analysis_name: str, timeout: int = 600) -> dict[str, Any]:
         """Run the CalculiX solver on an existing Fem::FemAnalysis and return summary results."""
         try:
@@ -294,6 +306,29 @@ class FreeCADRPC:
             return True
         except Exception as e:
             return str(e)
+
+
+    def _reload_document_gui(self, doc_name: str):
+        if doc_name not in FreeCAD.listDocuments():
+            return f"Document '{doc_name}' is not loaded."
+        doc = FreeCAD.getDocument(doc_name)
+        file_path = doc.FileName
+        if not file_path:
+            return (
+                f"Document '{doc_name}' has no file on disk "
+                "(unsaved scratch document); nothing to reload from."
+            )
+        if not os.path.exists(file_path):
+            return f"File for '{doc_name}' not found at {file_path!r}."
+        # Close, then reopen from the same file. Reopen preserves the
+        # original document name when the file was previously saved
+        # under that name.
+        FreeCAD.closeDocument(doc_name)
+        FreeCAD.openDocument(file_path)
+        FreeCAD.Console.PrintMessage(
+            f"Document '{doc_name}' reloaded from '{file_path}' via RPC.\n"
+        )
+        return True
 
     def _insert_part_from_library(self, relative_path):
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freecad-mcp"
-version = "0.1.17"
+version = "0.1.18"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/src/freecad_mcp/freecad_client.py
+++ b/src/freecad_mcp/freecad_client.py
@@ -53,6 +53,10 @@ class FreeCADConnection:
     def delete_object(self, doc_name: str, obj_name: str) -> dict[str, Any]:
         return self.server.delete_object(doc_name, obj_name)
 
+
+    def reload_document(self, doc_name: str) -> dict[str, Any]:
+        return self.server.reload_document(doc_name)
+
     def insert_part_from_library(self, relative_path: str) -> dict[str, Any]:
         return self.server.insert_part_from_library(relative_path)
 

--- a/src/freecad_mcp/operations/__init__.py
+++ b/src/freecad_mcp/operations/__init__.py
@@ -11,6 +11,7 @@ from .core import (
     get_view_operation,
     insert_part_from_library_operation,
     list_documents_operation,
+    reload_document_operation,
     run_fem_analysis_operation,
 )
 
@@ -27,5 +28,6 @@ __all__ = [
     "get_view_operation",
     "insert_part_from_library_operation",
     "list_documents_operation",
+    "reload_document_operation",
     "run_fem_analysis_operation",
 ]

--- a/src/freecad_mcp/operations/core.py
+++ b/src/freecad_mcp/operations/core.py
@@ -228,3 +228,23 @@ def run_fem_analysis_operation(
     except Exception as e:
         logger.error(f"Failed to run FEM analysis: {str(e)}")
         return text_response(f"Failed to run FEM analysis: {str(e)}")
+
+
+def reload_document_operation(
+    freecad: FreeCADConnection,
+    doc_name: str,
+) -> ToolResponse:
+    """Close and re-open a document so the GUI picks up external file
+    changes (e.g. headless edits via `freecadcmd`).
+    """
+    try:
+        res = freecad.reload_document(doc_name)
+        if res.get("success"):
+            return text_response(
+                f"Document '{res['document_name']}' reloaded from disk."
+            )
+        return text_response(f"Failed to reload document: {res.get('error')}")
+    except Exception as e:
+        logger.error(f"Failed to reload document: {str(e)}")
+        return text_response(f"Failed to reload document: {str(e)}")
+

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -19,6 +19,7 @@ from .operations import (
     get_view_operation,
     insert_part_from_library_operation,
     list_documents_operation,
+    reload_document_operation,
     run_fem_analysis_operation,
 )
 from .prompt_text import ASSET_CREATION_STRATEGY
@@ -415,6 +416,35 @@ def get_parts_list(ctx: Context) -> list[TextContent]:
     """Get the list of parts in the parts library addon.
     """
     return get_parts_list_operation(get_freecad_connection())
+
+
+@mcp.tool()
+def reload_document(ctx: Context, doc_name: str) -> list[TextContent]:
+    """Close and re-open a document to pick up external file changes.
+
+    Use this AFTER the document's .FCStd file has been modified by
+    something outside of FreeCAD's GUI process — for example, a
+    headless `freecadcmd` script that edited and saved the file. The
+    open GUI document is otherwise unaware of on-disk changes; this
+    tool closes the stale in-memory copy and reopens the file from
+    disk so the GUI shows current geometry.
+
+    Args:
+        doc_name: The name of the open document to reload. Must match
+            the name shown by ``list_documents``.
+
+    Returns:
+        A message confirming the document was reloaded, or describing
+        the failure (document not loaded, no associated file, etc).
+
+    Examples:
+        ```json
+        {
+            "doc_name": "chassis"
+        }
+        ```
+    """
+    return reload_document_operation(get_freecad_connection(), doc_name)
 
 
 @mcp.tool()


### PR DESCRIPTION
Hi there — first off, thank you so much for `freecad-mcp`. We've been
using it heavily over the past several weeks driving FreeCAD from an
LLM assistant for a custom plywood enclosure project, and the
existing tools cover almost everything we need. The headless
`freecadcmd` escape hatch + `execute_code` GUI bridge is a really
nice design.

This PR adds one small tool — `reload_document(doc_name)` — that
closes and reopens a document in the running GUI so it picks up
external file changes.

### Why

The pattern we keep landing on:

1. The LLM hits an op that's heavy or where streaming a screenshot
   back through `execute_code` is undesirable (large `Part.makeFillet`
   passes, FCStd reshapes, etc.). It drops to SSH + `freecadcmd`
   headless to do the work straight on the file.
2. After the headless op saves the FCStd, the user's open GUI
   document is now stale — FreeCAD doesn't watch the file for
   external changes.
3. Today the workaround is to call `execute_code` with
   `App.closeDocument(name); App.openDocument(path)`. That works, but
   it routes through the GUI-thread executor and the screenshot
   pipeline, which is heavier than the intent ("just refresh from
   disk").

A dedicated tool makes that intent explicit and is faster on the wire
since it skips the code-execution path and (when configured with
`--only-text-feedback`) skips the screenshot.

### Behavior

`reload_document(doc_name: str)`:

- Refuses if the document is not currently loaded.
- Refuses if the document has no associated file on disk (unsaved
  scratch doc — nothing to reload from).
- Refuses if the file no longer exists at the recorded path.
- Otherwise: `App.closeDocument(name)` then
  `App.openDocument(file_path)`, all dispatched on the GUI thread the
  same way the other tools are.

Both `closeDocument` and `openDocument` are stable FreeCAD APIs (1.x
and 0.21.x), and reopening from a previously-saved file preserves the
original document name, so the LLM can keep using the same `doc_name`
in subsequent calls.

### Footprint

6 files, +92 / -1. Strictly additive — no existing tools, RPC
signatures, or response shapes change. AST-checks pass and
`py_compile` is clean on the MCP-side files. I bumped
`pyproject.toml` from `0.1.17` → `0.1.18` since this is a new
feature; happy to revert that part if you'd rather handle versioning
yourself.

### Notes

Live RPC test against a running FreeCAD GUI: I deliberately didn't
include one in the PR — the AST + py_compile + diff review felt like
the right level of confidence for an additive tool that mirrors the
existing `create_document` pattern. Happy to add an integration test
script if you'd like one before merging.

If you'd rather not take this upstream, totally understood — we'll
maintain it on a fork for our own pipeline. Either way, thanks again
for the project. It's been genuinely useful for us, and a fun
collaborator-with-a-CAD-kernel kind of tool to use.

— Jason 