### PR TITLE
Fix AttributeError on non-geometric objects in serialize_view_object

### DIFF
--- a/addon/FreeCADMCP/rpc_server/serialize.py
+++ b/addon/FreeCADMCP/rpc_server/serialize.py
@@ -52,11 +52,20 @@ def serialize_shape(shape):
 def serialize_view_object(view):
     if view is None:
         return None
-    return {
-        "ShapeColor": serialize_value(view.ShapeColor),
-        "Transparency": view.Transparency,
-        "Visibility": view.Visibility,
-    }
+    result = {}
+    try:
+        result["ShapeColor"] = serialize_value(view.ShapeColor)
+    except AttributeError:
+        pass
+    try:
+        result["Transparency"] = view.Transparency
+    except AttributeError:
+        pass
+    try:
+        result["Visibility"] = view.Visibility
+    except AttributeError:
+        pass
+    return result
 
 
 def serialize_object(obj):


### PR DESCRIPTION
Hi — thank you for freecad-mcp. We've been using it to drive FreeCAD from an LLM assistant for a custom speaker enclosure project, and it's been a genuinely fun tool to work with. The execute_code / GUI-thread bridge design has held up really well for us.

This PR is a one-function bug fix — no new tools, no API changes.

**Why**

On FreeCAD 1.1.x, calling `get_objects` on a document that contains non-geometric objects crashes with:

```
AttributeError: 'Gui.ViewProviderDocumentObject' object has no attribute 'ShapeColor'
```

The issue is in `serialize_view_object`. It unconditionally reads `ShapeColor`, `Transparency`, and `Visibility` from the view provider, but objects like `PartDesign::Body`, `App::Origin`, `App::Part`, `Sketcher::SketchObject`, and similar non-shape types use a base `ViewProviderDocumentObject` that doesn't expose `ShapeColor` or `Transparency`. Only view providers descended from `Part::Feature` have those.

In my case, this resulted in `get_objects` being broken on any document that uses PartDesign.

**The fix**

Guard each attribute access with `try/except AttributeError` rather than `hasattr`. We deliberately chose `try/except` over `hasattr` because some FreeCAD view provider properties report `hasattr=True` but raise on access (computed properties). Exception handling is the more robust pattern here.

Objects whose view providers don't expose an attribute simply omit that key from the returned dict — so `App::Origin` comes back with just `{"Visibility": false}` instead of crashing.

**Footprint**

1 file, +14 / -5. Strictly additive in terms of behavior — objects that previously serialized correctly are unchanged. No RPC signatures or response shapes change (the dict was already open-ended).

Live-tested against FreeCAD 1.1.x with a PartDesign document containing Body, Origin, Sketches, Pad, Hole, Pocket, Fillet, and Chamfer objects — all serialize cleanly now.

— Ben