### PR TITLE
Fix wait-cursor flicker on idle RPC heartbeat

### DIFF
--- a/addon/FreeCADMCP/rpc_server/gui_dispatch.py
+++ b/addon/FreeCADMCP/rpc_server/gui_dispatch.py
@@ -108,6 +108,8 @@ def process_gui_tasks(reschedule: bool = True) -> None:
 
     shutdown = False
     try:
+        if _rpc_request_queue.empty():
+            return  # nothing queued; skip cursor/status-bar churn on idle heartbeat ticks
         if QtWidgets.QApplication.mouseButtons() != QtCore.Qt.NoButton:
             return  # user is dragging; defer to next tick
         if QtWidgets.QApplication.activePopupWidget() is not None:


### PR DESCRIPTION
## Problem

Fixes #69.

While the RPC server is running, the mouse cursor flickers between the normal cursor and the wait cursor every 500 ms, even when FreeCAD is completely idle (no MCP request in flight).

## Root cause

`process_gui_tasks()` in `addon/FreeCADMCP/rpc_server/gui_dispatch.py` is invoked on every 500 ms heartbeat tick (and immediately on wake). It unconditionally calls `app.setOverrideCursor(QtCore.Qt.WaitCursor)` and `status_bar.showMessage(...)` before checking whether there is anything to process, then immediately undoes both in the `finally` block if `_rpc_request_queue` was empty. On an idle system that set/restore cycle repeats every 500 ms, producing the visible cursor blink.

## Fix

Add an early return when `_rpc_request_queue` is empty, before any cursor/status-bar mutation:

```python
shutdown = False
try:
    if _rpc_request_queue.empty():
        return  # nothing queued; skip cursor/status-bar churn on idle heartbeat ticks
    if QtWidgets.QApplication.mouseButtons() != QtCore.Qt.NoButton:
        return  # user is dragging; defer to next tick
    ...
```

This early return sits inside the existing outer `try`, so the `finally` block still reschedules the 500 ms heartbeat exactly as it does for the other early-return branches (mouse held, popup open, modal open) — the fallback heartbeat is unaffected. The wait cursor and status message are now only shown when a task is actually about to run.

## Testing

There's no FreeCAD install available in the environment I developed this in, and the repo has no automated test suite, so I verified the change with a small mock harness that stubs `FreeCAD`/`FreeCADGui`/`PySide` and exercises `process_gui_tasks()` directly against the real module code. It confirms:
- an idle tick (empty queue) touches the cursor/status bar zero times but still reschedules the heartbeat
- a tick with a queued task still sets/restores the wait cursor and runs the task
- the mouse-drag guard still defers processing and reschedules correctly

I'd appreciate it if someone with a live FreeCAD + the addon installed could confirm the cursor no longer blinks at idle and still shows correctly during an active MCP call, since I wasn't able to check that visually myself.
