### PR TITLE
Add run_macro tool for executing FreeCAD macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ The `--host` value is validated on startup — it must be a valid IPv4/IPv6 addr
 * `edit_object`: Edit an object in FreeCAD.
 * `delete_object`: Delete an object in FreeCAD.
 * `execute_code`: Execute arbitrary Python code in FreeCAD.
+* `run_macro`: Execute a FreeCAD macro (`.FCMacro`/`.py`) file, with `__file__` and `sys.path` set up correctly so macros relying on relative resource loading or sibling-module imports work the same way they would from FreeCAD's Macro menu.
 * `insert_part_from_library`: Insert a part from the [parts library](https://github.com/FreeCAD/FreeCAD-library).
 * `get_view`: Get a screenshot of the active view.
 * `get_objects`: Get all objects in a document.

--- a/addon/FreeCADMCP/rpc_server/macro_runner.py
+++ b/addon/FreeCADMCP/rpc_server/macro_runner.py
@@ -1,0 +1,62 @@
+"""FreeCAD macro (.FCMacro) execution with proper __file__/sys.path context.
+
+Plain-function module (macro path + exec globals in, plain dict out),
+mirroring the fem_executor.py / step_io.py convention.
+"""
+
+import contextlib
+import io
+import os
+import sys
+import traceback
+
+
+def run_macro(macro_path: str, exec_globals: dict) -> dict:
+    """Execute a macro file on the caller's globals, with __file__ set to
+    the macro's own path and its directory added to sys.path for the
+    duration of the run.
+
+    Unlike plain execute_code (exec(code, globals())), this sets up the
+    context a macro run from FreeCAD's Macro menu would have: __file__
+    pointing at itself (for relative resource loading) and its own
+    directory importable (for sibling helper modules).
+    """
+    if not os.path.isfile(macro_path):
+        return {"success": False, "error": f"Macro file not found: {macro_path}"}
+
+    try:
+        with open(macro_path, "r", encoding="utf-8") as f:
+            code = f.read()
+    except Exception as e:
+        return {"success": False, "error": f"Could not read macro file: {type(e).__name__}: {e}"}
+
+    macro_path = os.path.abspath(macro_path)
+    macro_dir = os.path.dirname(macro_path)
+
+    had_file = "__file__" in exec_globals
+    original_file = exec_globals.get("__file__")
+    exec_globals["__file__"] = macro_path
+
+    path_inserted = macro_dir not in sys.path
+    if path_inserted:
+        sys.path.insert(0, macro_dir)
+
+    output_buffer = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(output_buffer):
+            exec(compile(code, macro_path, "exec"), exec_globals)
+        return {"success": True, "message": "Macro executed successfully.", "output": output_buffer.getvalue()}
+    except Exception as e:
+        return {
+            "success": False,
+            "error": f"{type(e).__name__}: {e}",
+            "traceback": traceback.format_exc(),
+            "output": output_buffer.getvalue(),
+        }
+    finally:
+        if path_inserted and macro_dir in sys.path:
+            sys.path.remove(macro_dir)
+        if had_file:
+            exec_globals["__file__"] = original_file
+        else:
+            exec_globals.pop("__file__", None)

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -21,6 +21,7 @@ from rpc_server.gui_dispatch import (
     request_shutdown,
 )
 from rpc_server.ip_filter import FilteredXMLRPCServer, validate_allowed_ips
+from rpc_server.macro_runner import run_macro as _run_macro
 from rpc_server.object_factory import create_object_gui
 from rpc_server.parts_library import get_parts_list, insert_part_from_library
 from rpc_server.property_mapper import Object, set_object_property
@@ -174,6 +175,31 @@ class FreeCADRPC:
             f"--- code ---\n{code_preview}\n--- end ---\n"
         )
         return _err(res)
+
+    def run_macro(self, macro_path: str, timeout: int = 90) -> dict[str, Any]:
+        """Execute a FreeCAD macro (.FCMacro/.py) file on the GUI thread.
+
+        Unlike execute_code, this sets __file__ to the macro's own path and
+        temporarily adds its directory to sys.path, so macros that rely on
+        __file__ for relative resource loading or sibling-module imports
+        work the same way they would from FreeCAD's Macro menu.
+        """
+        try:
+            timeout_s = int(timeout)
+        except (TypeError, ValueError):
+            return {"success": False, "error": f"invalid timeout: {timeout!r}"}
+
+        def task():
+            return _run_macro(macro_path, globals())
+
+        res = dispatch_to_gui(task, timeout=timeout_s)
+        if isinstance(res, dict):
+            if res.get("success"):
+                FreeCAD.Console.PrintMessage(f"Macro '{macro_path}' executed via RPC.\n")
+            else:
+                FreeCAD.Console.PrintError(f"Error executing macro '{macro_path}': {res.get('error')}\n")
+            return res
+        return {"success": False, "error": str(res)}
 
     def get_objects(self, doc_name):
         # FreeCAD.getDocument raises (not returns None) for an unknown name.

--- a/src/freecad_mcp/freecad_client.py
+++ b/src/freecad_mcp/freecad_client.py
@@ -71,6 +71,13 @@ class FreeCADConnection:
     def execute_code_async(self, code: str) -> dict[str, Any]:
         return self.server.execute_code_async(code)
 
+    def run_macro(self, macro_path: str, timeout: int = 90) -> dict[str, Any]:
+        # Macros can run arbitrarily long; use a dedicated proxy whose socket
+        # timeout exceeds the requested run timeout, same rationale as
+        # run_fem_analysis's dedicated proxy below.
+        proxy = self._make_proxy(max(self._timeout, timeout + 30))
+        return proxy.run_macro(macro_path, timeout)
+
     def get_active_screenshot(
         self,
         view_name: str = "Isometric",

--- a/src/freecad_mcp/operations/__init__.py
+++ b/src/freecad_mcp/operations/__init__.py
@@ -13,6 +13,7 @@ from .core import (
     list_documents_operation,
     reload_document_operation,
     run_fem_analysis_operation,
+    run_macro_operation,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "list_documents_operation",
     "reload_document_operation",
     "run_fem_analysis_operation",
+    "run_macro_operation",
 ]

--- a/src/freecad_mcp/operations/core.py
+++ b/src/freecad_mcp/operations/core.py
@@ -127,6 +127,25 @@ def execute_code_async_operation(
         return text_response(f"Failed to start async code execution: {str(e)}")
 
 
+def run_macro_operation(
+    freecad: FreeCADConnection,
+    only_text_feedback: bool,
+    macro_path: str,
+    timeout: int = 90,
+) -> ToolResponse:
+    try:
+        res = freecad.run_macro(macro_path, timeout)
+        if res.get("success"):
+            response = text_response(f"Macro executed successfully.\nOutput: {res.get('output', '')}")
+        else:
+            return text_response(f"Failed to run macro: {res.get('error')}")
+        screenshot = None if only_text_feedback else freecad.get_active_screenshot()
+        return add_screenshot_if_available(response, screenshot, only_text_feedback)
+    except Exception as e:
+        logger.error(f"Failed to run macro: {str(e)}")
+        return text_response(f"Failed to run macro: {str(e)}")
+
+
 def get_view_operation(
     freecad: FreeCADConnection,
     view_name: str,

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -21,6 +21,7 @@ from .operations import (
     list_documents_operation,
     reload_document_operation,
     run_fem_analysis_operation,
+    run_macro_operation,
 )
 from .prompt_text import ASSET_CREATION_STRATEGY
 from .server_state import ServerState
@@ -326,6 +327,31 @@ def execute_code(ctx: Context, code: str) -> list[TextContent | ImageContent]:
         A message indicating the success or failure of the code execution, the output of the code execution, and a screenshot of the object.
     """
     return execute_code_operation(get_freecad_connection(), state.only_text_feedback, code)
+
+
+@mcp.tool()
+def run_macro(
+    ctx: Context, macro_path: str, timeout: int = 90
+) -> list[TextContent | ImageContent]:
+    """Execute a FreeCAD macro (.FCMacro or .py) file on the GUI thread.
+
+    Unlike execute_code, this sets __file__ to the macro's own path and
+    temporarily adds its directory to sys.path before running it, so macros
+    that rely on __file__ for relative resource loading or that import
+    sibling helper modules work the same way they would from FreeCAD's
+    Macro menu.
+
+    Args:
+        macro_path: The local filesystem path of the macro file to run.
+        timeout: Seconds to wait for the macro to finish (default 90).
+
+    Returns:
+        A message with the macro's captured stdout output (or the error),
+        and a screenshot of the object.
+    """
+    return run_macro_operation(
+        get_freecad_connection(), state.only_text_feedback, macro_path, timeout
+    )
 
 
 @mcp.tool()


### PR DESCRIPTION
## Problem

Addresses #59.

A user asked whether an AI client can run a FreeCAD macro through this MCP server. `mooyax` confirmed the existing `execute_code` tool works as a workaround, but pointed out its limitation:

> One limitation to be aware of: macros that rely on `__file__` for relative imports or resource loading may not work correctly, since `__file__` will not point to the macro's own path in this context.
>
> A dedicated `run_macro` tool (with proper `__file__` and `sys.path` setup) could be added in the future, but for most straightforward macros the `execute_code` approach works fine.

This PR adds that dedicated tool.

## What's added

**`run_macro(macro_path, timeout=90)`**, following the existing three-layer pattern (addon RPC method → `FreeCADConnection` client wrapper → `operations/core.py` → `@mcp.tool()`), with the logic in a new `addon/FreeCADMCP/rpc_server/macro_runner.py` module (mirroring the `fem_executor.py`/`step_io.py` convention of plain, dispatch-agnostic functions).

Unlike `execute_code`, which runs `exec(code, globals())` using `rpc_server.py`'s own module globals unmodified, `run_macro`:
1. Reads the macro file's source.
2. Temporarily sets `__file__` in the shared exec globals to the macro's own absolute path (restoring the original value afterward).
3. Temporarily inserts the macro's directory at the front of `sys.path` (removing it afterward), so sibling helper modules the macro imports are found.
4. Executes on the GUI thread via the existing `dispatch_to_gui`, same as `execute_code`/`create_object`, since macros commonly touch the document tree.
5. Captures stdout the same way `execute_code` does.

It still executes in the same shared globals namespace as `execute_code` (so macros can see state left by prior `execute_code`/`run_macro` calls, consistent with existing behavior) — only `__file__` is scoped to the macro's own run and cleaned up afterward.

## Testing

No automated test suite exists in this repo; verified end-to-end against a live FreeCAD 1.1.1 instance with a macro that reproduces the exact limitation from #59 — loading a sibling resource file via `__file__`:

```python
import os
macro_dir = os.path.dirname(os.path.abspath(__file__))
with open(os.path.join(macro_dir, "helper_data.txt")) as f:
    print("Loaded sibling resource:", f.read().strip())
```

1. **Reproduced the bug**: running this exact code via plain `execute_code` fails with `FileNotFoundError`, because `__file__` resolves to the addon's own `rpc_server.py` path, not the macro's.
2. **Confirmed the fix**: running the same file via the new `run_macro` tool succeeds — `__file__` correctly points at the macro's own path and the sibling resource loads.
3. **Confirmed cleanup**: a subsequent `execute_code` call immediately after shows `__file__` restored to `rpc_server.py`'s own path and the macro's directory no longer in `sys.path` — so `run_macro` doesn't leak state into later `execute_code` calls.

README's Tools list is updated.
