### PR TITLE
Add beacon.json for Beacon discovery listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,9 @@ The `--host` value is validated on startup — it must be a valid IPv4/IPv6 addr
 </a>
 
 Made with [contrib.rocks](https://contrib.rocks).
+
+## Discovery
+
+[![Beacon Verified](https://registry-ruby.vercel.app/api/v1/agents/neka-nat%2Ffreecad-mcp/badge.svg)](https://portal-five-phi-54.vercel.app/?q=neka-nat%2Ffreecad-mcp)
+
+Listed on [Beacon](https://portal-five-phi-54.vercel.app) — searchable index of open-source MCP servers.

--- a/beacon.json
+++ b/beacon.json
@@ -1,0 +1,23 @@
+{
+  "beacon_manifest": "0.1",
+  "id": "neka-nat/freecad-mcp",
+  "name": "Freecad Mcp",
+  "description": "Open-source AI agent \u2014 claude, freecad, mcp, model.",
+  "capabilities": [
+    "claude",
+    "freecad",
+    "mcp",
+    "model",
+    "context",
+    "protocol",
+    "server"
+  ],
+  "interfaces": [
+    {
+      "type": "mcp",
+      "endpoint": "https://github.com/neka-nat/freecad-mcp"
+    }
+  ],
+  "source": "https://github.com/neka-nat/freecad-mcp",
+  "homepage": "https://github.com/neka-nat/freecad-mcp"
+}


### PR DESCRIPTION
Adds Beacon Agent Manifest v0.1 for capability search on https://portal-five-phi-54.vercel.app — opt-in metadata, no runtime changes. Spec: https://github.com/enrichgateagent-png/beacon-agent-manifest

Made with [Cursor](https://cursor.com)