### PR TITLE
Add per-call include_screenshot and view_name parameters to screenshot tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ If you want to save token, you can set `only_text_feedback` to `true` and use on
 }
 ```
 
+Screenshots can also be controlled per tool call instead of globally: every tool that returns a screenshot accepts an optional `include_screenshot` parameter (pass `false` to get text-only feedback, e.g. for analytical scripts or intermediate steps) and an optional `view_name` parameter to orient the screenshot ("Isometric" by default, or "Front", "Top", "Right", etc.). The `--only-text-feedback` flag always wins: when it is set, no screenshots are returned regardless of `include_screenshot`.
+
 
 For developer.
 First, you need clone this repository.
@@ -187,6 +189,8 @@ The `--host` value is validated on startup — it must be a valid IPv4/IPv6 addr
 * `get_object`: Get an object in a document.
 * `get_parts_list`: Get the list of parts in the [parts library](https://github.com/FreeCAD/FreeCAD-library).
 * `run_fem_analysis`: Run the CalculiX solver on an existing `Fem::FemAnalysis` and return summary results (max von Mises stress, max displacement, node count, working directory). Auto-creates a `SolverCcxTools` if the analysis has none. See [`examples/cantilever_fem.py`](examples/cantilever_fem.py) for an end-to-end usage example.
+
+Tools that return a screenshot (`create_object`, `edit_object`, `delete_object`, `execute_code`, `insert_part_from_library`, `get_objects`, `get_object`, `run_fem_analysis`) accept optional `include_screenshot` (default `true`) and `view_name` (default `"Isometric"`) parameters to suppress or reorient the returned image per call.
 
 ## Contributors
 

--- a/src/freecad_mcp/operations/core.py
+++ b/src/freecad_mcp/operations/core.py
@@ -29,6 +29,8 @@ def create_object_operation(
     obj_name: str,
     analysis_name: str | None = None,
     obj_properties: dict[str, Any] | None = None,
+    include_screenshot: bool = True,
+    view_name: str = "Isometric",
 ) -> ToolResponse:
     try:
         obj_data = {
@@ -42,8 +44,9 @@ def create_object_operation(
             response = text_response(f"Object '{res['object_name']}' created successfully")
         else:
             return text_response(f"Failed to create object: {res['error']}")
-        screenshot = None if only_text_feedback else freecad.get_active_screenshot()
-        return add_screenshot_if_available(response, screenshot, only_text_feedback)
+        skip_screenshot = only_text_feedback or not include_screenshot
+        screenshot = None if skip_screenshot else freecad.get_active_screenshot(view_name)
+        return add_screenshot_if_available(response, screenshot, skip_screenshot)
     except Exception as e:
         logger.error(f"Failed to create object: {str(e)}")
         return text_response(f"Failed to create object: {str(e)}")
@@ -55,6 +58,8 @@ def edit_object_operation(
     doc_name: str,
     obj_name: str,
     obj_properties: dict[str, Any],
+    include_screenshot: bool = True,
+    view_name: str = "Isometric",
 ) -> ToolResponse:
     try:
         res = freecad.edit_object(doc_name, obj_name, {"Properties": obj_properties})
@@ -62,8 +67,9 @@ def edit_object_operation(
             response = text_response(f"Object '{res['object_name']}' edited successfully")
         else:
             return text_response(f"Failed to edit object: {res['error']}")
-        screenshot = None if only_text_feedback else freecad.get_active_screenshot()
-        return add_screenshot_if_available(response, screenshot, only_text_feedback)
+        skip_screenshot = only_text_feedback or not include_screenshot
+        screenshot = None if skip_screenshot else freecad.get_active_screenshot(view_name)
+        return add_screenshot_if_available(response, screenshot, skip_screenshot)
     except Exception as e:
         logger.error(f"Failed to edit object: {str(e)}")
         return text_response(f"Failed to edit object: {str(e)}")
@@ -74,6 +80,8 @@ def delete_object_operation(
     only_text_feedback: bool,
     doc_name: str,
     obj_name: str,
+    include_screenshot: bool = True,
+    view_name: str = "Isometric",
 ) -> ToolResponse:
     try:
         res = freecad.delete_object(doc_name, obj_name)
@@ -81,8 +89,9 @@ def delete_object_operation(
             response = text_response(f"Object '{res['object_name']}' deleted successfully")
         else:
             return text_response(f"Failed to delete object: {res['error']}")
-        screenshot = None if only_text_feedback else freecad.get_active_screenshot()
-        return add_screenshot_if_available(response, screenshot, only_text_feedback)
+        skip_screenshot = only_text_feedback or not include_screenshot
+        screenshot = None if skip_screenshot else freecad.get_active_screenshot(view_name)
+        return add_screenshot_if_available(response, screenshot, skip_screenshot)
     except Exception as e:
         logger.error(f"Failed to delete object: {str(e)}")
         return text_response(f"Failed to delete object: {str(e)}")
@@ -92,6 +101,8 @@ def execute_code_operation(
     freecad: FreeCADConnection,
     only_text_feedback: bool,
     code: str,
+    include_screenshot: bool = True,
+    view_name: str = "Isometric",
 ) -> ToolResponse:
     try:
         res = freecad.execute_code(code)
@@ -100,8 +111,9 @@ def execute_code_operation(
             # Only attempt screenshot when code completed and screenshots are wanted.
             # Skipping on failure avoids a second hanging call while the worker thread
             # may still be running.
-            screenshot = None if only_text_feedback else freecad.get_active_screenshot()
-            return add_screenshot_if_available(response, screenshot, only_text_feedback)
+            skip_screenshot = only_text_feedback or not include_screenshot
+            screenshot = None if skip_screenshot else freecad.get_active_screenshot(view_name)
+            return add_screenshot_if_available(response, screenshot, skip_screenshot)
         return text_response(f"Failed to execute code: {res['error']}")
     except Exception as e:
         logger.error(f"Failed to execute code: {str(e)}")
@@ -144,6 +156,8 @@ def insert_part_from_library_operation(
     freecad: FreeCADConnection,
     only_text_feedback: bool,
     relative_path: str,
+    include_screenshot: bool = True,
+    view_name: str = "Isometric",
 ) -> ToolResponse:
     try:
         res = freecad.insert_part_from_library(relative_path)
@@ -151,8 +165,9 @@ def insert_part_from_library_operation(
             response = text_response(f"Part inserted from library: {res['message']}")
         else:
             return text_response(f"Failed to insert part from library: {res['error']}")
-        screenshot = None if only_text_feedback else freecad.get_active_screenshot()
-        return add_screenshot_if_available(response, screenshot, only_text_feedback)
+        skip_screenshot = only_text_feedback or not include_screenshot
+        screenshot = None if skip_screenshot else freecad.get_active_screenshot(view_name)
+        return add_screenshot_if_available(response, screenshot, skip_screenshot)
     except Exception as e:
         logger.error(f"Failed to insert part from library: {str(e)}")
         return text_response(f"Failed to insert part from library: {str(e)}")
@@ -162,11 +177,14 @@ def get_objects_operation(
     freecad: FreeCADConnection,
     only_text_feedback: bool,
     doc_name: str,
+    include_screenshot: bool = True,
+    view_name: str = "Isometric",
 ) -> ToolResponse:
     try:
         response = json_response(freecad.get_objects(doc_name))
-        screenshot = None if only_text_feedback else freecad.get_active_screenshot()
-        return add_screenshot_if_available(response, screenshot, only_text_feedback)
+        skip_screenshot = only_text_feedback or not include_screenshot
+        screenshot = None if skip_screenshot else freecad.get_active_screenshot(view_name)
+        return add_screenshot_if_available(response, screenshot, skip_screenshot)
     except Exception as e:
         logger.error(f"Failed to get objects: {str(e)}")
         return text_response(f"Failed to get objects: {str(e)}")
@@ -177,11 +195,14 @@ def get_object_operation(
     only_text_feedback: bool,
     doc_name: str,
     obj_name: str,
+    include_screenshot: bool = True,
+    view_name: str = "Isometric",
 ) -> ToolResponse:
     try:
         response = json_response(freecad.get_object(doc_name, obj_name))
-        screenshot = None if only_text_feedback else freecad.get_active_screenshot()
-        return add_screenshot_if_available(response, screenshot, only_text_feedback)
+        skip_screenshot = only_text_feedback or not include_screenshot
+        screenshot = None if skip_screenshot else freecad.get_active_screenshot(view_name)
+        return add_screenshot_if_available(response, screenshot, skip_screenshot)
     except Exception as e:
         logger.error(f"Failed to get object: {str(e)}")
         return text_response(f"Failed to get object: {str(e)}")
@@ -208,13 +229,16 @@ def run_fem_analysis_operation(
     doc_name: str,
     analysis_name: str,
     timeout: int = 600,
+    include_screenshot: bool = True,
+    view_name: str = "Isometric",
 ) -> ToolResponse:
     try:
         res = freecad.run_fem_analysis(doc_name, analysis_name, timeout)
         if res.get("success"):
             def fmt(v, unit):
                 return f"{v:.4g} {unit}" if isinstance(v, (int, float)) else f"unavailable ({unit})"
-            screenshot = freecad.get_active_screenshot() if not only_text_feedback else None
+            skip_screenshot = only_text_feedback or not include_screenshot
+            screenshot = None if skip_screenshot else freecad.get_active_screenshot(view_name)
             response = json_response({
                 "summary": (
                     f"FEM analysis '{analysis_name}' solved. "
@@ -224,7 +248,7 @@ def run_fem_analysis_operation(
                 ),
                 **res,
             })
-            return add_screenshot_if_available(response, screenshot, only_text_feedback)
+            return add_screenshot_if_available(response, screenshot, skip_screenshot)
         return json_response({
             "summary": f"FEM analysis '{analysis_name}' failed: {res.get('error')}",
             **res,

--- a/src/freecad_mcp/prompt_text.py
+++ b/src/freecad_mcp/prompt_text.py
@@ -21,6 +21,17 @@ When creating content in FreeCAD, always follow these steps:
 
 6. If detailed customization or specialized operations are necessary, use execute_code() to run custom Python scripts.
 
+7. Manage screenshot feedback to save tokens. Tools that modify or inspect the
+   model accept optional `include_screenshot` and `view_name` parameters:
+   - Pass include_screenshot=False when the image would not be informative:
+     analytical or computational scripts whose result is printed output,
+     bulk property edits, or intermediate steps in a longer sequence of
+     changes where only the final state needs visual confirmation.
+   - Pass view_name (e.g. "Front", "Top", "Right") to orient the screenshot
+     toward the part of the model you changed; the default is "Isometric".
+   - When you skipped screenshots during intermediate steps, use get_view()
+     afterwards to visually inspect the result from the most informative angle.
+
 Only revert to basic creation methods in the following cases:
 - When the required asset is not available in the parts library.
 - When a basic shape is explicitly requested.

--- a/src/freecad_mcp/prompt_text.py
+++ b/src/freecad_mcp/prompt_text.py
@@ -28,7 +28,7 @@ When creating content in FreeCAD, always follow these steps:
      bulk property edits, or intermediate steps in a longer sequence of
      changes where only the final state needs visual confirmation.
    - Pass view_name (e.g. "Front", "Top", "Right") to orient the screenshot
-     toward the part of the model you changed; the default is "Isometric".
+     toward the part of the model you changed; the default is "Isometric" (top-front-right).
    - When you skipped screenshots during intermediate steps, use get_view()
      afterwards to visually inspect the result from the most informative angle.
 

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -32,6 +32,10 @@ logging.basicConfig(
 logger = logging.getLogger("FreeCADMCPserver")
 logger.setLevel(logging.INFO)
 
+ViewName = Literal[
+    "Isometric", "Front", "Top", "Right", "Back", "Left", "Bottom", "Dimetric", "Trimetric"
+]
+
 state = ServerState()
 
 
@@ -105,6 +109,8 @@ def create_object(
     obj_name: str,
     analysis_name: str | None = None,
     obj_properties: dict[str, Any] = None,
+    include_screenshot: bool = True,
+    view_name: ViewName = "Isometric",
 ) -> list[TextContent | ImageContent]:
     """Create a new object in FreeCAD.
     Object type is starts with "Part::" or "Draft::" or "PartDesign::" or "Fem::".
@@ -114,6 +120,11 @@ def create_object(
         obj_type: The type of the object to create (e.g. 'Part::Box', 'Part::Cylinder', 'Draft::Circle', 'PartDesign::Body', etc.).
         obj_name: The name of the object to create.
         obj_properties: The properties of the object to create.
+        include_screenshot: Whether to return a screenshot of the model (default True).
+            Set to False to save tokens when visual feedback is not needed,
+            e.g. for intermediate steps in a longer sequence of changes.
+        view_name: The view orientation of the returned screenshot (default "Isometric").
+            Pick the view that best shows the change being made.
 
     Returns:
         A message indicating the success or failure of the object creation and a screenshot of the object.
@@ -230,12 +241,19 @@ def create_object(
         obj_name,
         analysis_name,
         obj_properties,
+        include_screenshot,
+        view_name,
     )
 
 
 @mcp.tool()
 def edit_object(
-    ctx: Context, doc_name: str, obj_name: str, obj_properties: dict[str, Any]
+    ctx: Context,
+    doc_name: str,
+    obj_name: str,
+    obj_properties: dict[str, Any],
+    include_screenshot: bool = True,
+    view_name: ViewName = "Isometric",
 ) -> list[TextContent | ImageContent]:
     """Edit an object in FreeCAD.
     This tool is used when the `create_object` tool cannot handle the object creation.
@@ -244,6 +262,11 @@ def edit_object(
         doc_name: The name of the document to edit the object in.
         obj_name: The name of the object to edit.
         obj_properties: The properties of the object to edit.
+        include_screenshot: Whether to return a screenshot of the model (default True).
+            Set to False to save tokens when visual feedback is not needed,
+            e.g. for intermediate steps in a longer sequence of changes.
+        view_name: The view orientation of the returned screenshot (default "Isometric").
+            Pick the view that best shows the change being made.
 
     Returns:
         A message indicating the success or failure of the object editing and a screenshot of the object.
@@ -254,16 +277,29 @@ def edit_object(
         doc_name,
         obj_name,
         obj_properties,
+        include_screenshot,
+        view_name,
     )
 
 
 @mcp.tool()
-def delete_object(ctx: Context, doc_name: str, obj_name: str) -> list[TextContent | ImageContent]:
+def delete_object(
+    ctx: Context,
+    doc_name: str,
+    obj_name: str,
+    include_screenshot: bool = True,
+    view_name: ViewName = "Isometric",
+) -> list[TextContent | ImageContent]:
     """Delete an object in FreeCAD.
 
     Args:
         doc_name: The name of the document to delete the object from.
         obj_name: The name of the object to delete.
+        include_screenshot: Whether to return a screenshot of the model (default True).
+            Set to False to save tokens when visual feedback is not needed,
+            e.g. for intermediate steps in a longer sequence of changes.
+        view_name: The view orientation of the returned screenshot (default "Isometric").
+            Pick the view that best shows the change being made.
 
     Returns:
         A message indicating the success or failure of the object deletion and a screenshot of the object.
@@ -273,6 +309,8 @@ def delete_object(ctx: Context, doc_name: str, obj_name: str) -> list[TextConten
         state.only_text_feedback,
         doc_name,
         obj_name,
+        include_screenshot,
+        view_name,
     )
 
 
@@ -316,22 +354,39 @@ def execute_code_async(ctx: Context, code: str) -> list[TextContent]:
 
 
 @mcp.tool()
-def execute_code(ctx: Context, code: str) -> list[TextContent | ImageContent]:
+def execute_code(
+    ctx: Context,
+    code: str,
+    include_screenshot: bool = True,
+    view_name: ViewName = "Isometric",
+) -> list[TextContent | ImageContent]:
     """Execute arbitrary Python code in FreeCAD.
 
     Args:
         code: The Python code to execute.
+        include_screenshot: Whether to return a screenshot of the model (default True).
+            Set to False to save tokens when the code does not change the model's
+            appearance, e.g. analytical or computational scripts whose result is
+            printed output, or intermediate steps in a longer sequence of changes.
+        view_name: The view orientation of the returned screenshot (default "Isometric").
+            Pick the view that best shows the change being made.
 
     Returns:
         A message indicating the success or failure of the code execution, the output of the code execution, and a screenshot of the object.
     """
-    return execute_code_operation(get_freecad_connection(), state.only_text_feedback, code)
+    return execute_code_operation(
+        get_freecad_connection(),
+        state.only_text_feedback,
+        code,
+        include_screenshot,
+        view_name,
+    )
 
 
 @mcp.tool()
 def get_view(
     ctx: Context,
-    view_name: Literal["Isometric", "Front", "Top", "Right", "Back", "Left", "Bottom", "Dimetric", "Trimetric"],
+    view_name: ViewName,
     width: int | None = None,
     height: int | None = None,
     focus_object: str | None = None,
@@ -361,11 +416,21 @@ def get_view(
 
 
 @mcp.tool()
-def insert_part_from_library(ctx: Context, relative_path: str) -> list[TextContent | ImageContent]:
+def insert_part_from_library(
+    ctx: Context,
+    relative_path: str,
+    include_screenshot: bool = True,
+    view_name: ViewName = "Isometric",
+) -> list[TextContent | ImageContent]:
     """Insert a part from the parts library addon.
 
     Args:
         relative_path: The relative path of the part to insert.
+        include_screenshot: Whether to return a screenshot of the model (default True).
+            Set to False to save tokens when visual feedback is not needed,
+            e.g. for intermediate steps in a longer sequence of changes.
+        view_name: The view orientation of the returned screenshot (default "Isometric").
+            Pick the view that best shows the change being made.
 
     Returns:
         A message indicating the success or failure of the part insertion and a screenshot of the object.
@@ -374,31 +439,56 @@ def insert_part_from_library(ctx: Context, relative_path: str) -> list[TextConte
         get_freecad_connection(),
         state.only_text_feedback,
         relative_path,
+        include_screenshot,
+        view_name,
     )
 
 
 @mcp.tool()
-def get_objects(ctx: Context, doc_name: str) -> list[TextContent | ImageContent]:
+def get_objects(
+    ctx: Context,
+    doc_name: str,
+    include_screenshot: bool = True,
+    view_name: ViewName = "Isometric",
+) -> list[TextContent | ImageContent]:
     """Get all objects in a document.
     You can use this tool to get the objects in a document to see what you can check or edit.
 
     Args:
         doc_name: The name of the document to get the objects from.
+        include_screenshot: Whether to return a screenshot of the document (default True).
+            Set to False to save tokens when only the object data is needed.
+        view_name: The view orientation of the returned screenshot (default "Isometric").
 
     Returns:
         A list of objects in the document and a screenshot of the document.
     """
-    return get_objects_operation(get_freecad_connection(), state.only_text_feedback, doc_name)
+    return get_objects_operation(
+        get_freecad_connection(),
+        state.only_text_feedback,
+        doc_name,
+        include_screenshot,
+        view_name,
+    )
 
 
 @mcp.tool()
-def get_object(ctx: Context, doc_name: str, obj_name: str) -> list[TextContent | ImageContent]:
+def get_object(
+    ctx: Context,
+    doc_name: str,
+    obj_name: str,
+    include_screenshot: bool = True,
+    view_name: ViewName = "Isometric",
+) -> list[TextContent | ImageContent]:
     """Get an object from a document.
     You can use this tool to get the properties of an object to see what you can check or edit.
 
     Args:
         doc_name: The name of the document to get the object from.
         obj_name: The name of the object to get.
+        include_screenshot: Whether to return a screenshot of the document (default True).
+            Set to False to save tokens when only the object data is needed.
+        view_name: The view orientation of the returned screenshot (default "Isometric").
 
     Returns:
         The object and a screenshot of the object.
@@ -408,6 +498,8 @@ def get_object(ctx: Context, doc_name: str, obj_name: str) -> list[TextContent |
         state.only_text_feedback,
         doc_name,
         obj_name,
+        include_screenshot,
+        view_name,
     )
 
 
@@ -463,6 +555,8 @@ def run_fem_analysis(
     doc_name: str,
     analysis_name: str,
     timeout: int = 600,
+    include_screenshot: bool = True,
+    view_name: ViewName = "Isometric",
 ) -> list[TextContent | ImageContent]:
     """Run the CalculiX solver on an existing Fem::FemAnalysis container and return summary results.
 
@@ -489,6 +583,9 @@ def run_fem_analysis(
         doc_name: Name of the FreeCAD document.
         analysis_name: Name of the Fem::AnalysisPython object.
         timeout: Seconds to wait for the solver (default 600).
+        include_screenshot: Whether to return a screenshot of the model (default True).
+            Set to False to save tokens when only the numeric results are needed.
+        view_name: The view orientation of the returned screenshot (default "Isometric").
     """
     return run_fem_analysis_operation(
         get_freecad_connection(),
@@ -496,6 +593,8 @@ def run_fem_analysis(
         doc_name,
         analysis_name,
         timeout,
+        include_screenshot,
+        view_name,
     )
 
 


### PR DESCRIPTION
## What

Adds two optional parameters to every tool that returns a screenshot (`create_object`, `edit_object`, `delete_object`, `execute_code`, `insert_part_from_library`, `get_objects`, `get_object`, `run_fem_analysis`):

- `include_screenshot` (default `true`) — pass `false` to skip the screenshot entirely. The capture RPC is not made at all, so it saves both tokens and time.
- `view_name` (default `"Isometric"`) — orient the returned screenshot toward the change, using the same nine views `get_view` already supports. The addon RPC already accepted `view_name`, so no addon changes were needed.

The `asset_creation_strategy` prompt, the tool docstrings, and the README now include guidance on when to suppress screenshots (analytical/computational scripts, intermediate iteration steps) and how to pick an informative view, including using `get_view()` for a final visual check after suppressed steps.

## Why

Closes #78. Agents running analytical scripts or making minor iterations always received an isometric screenshot, which was often uninformative and burned tokens. Previously the only control was the global `--only-text-feedback` flag — all or nothing for the whole session.

## Notes for review

- The global `--only-text-feedback` flag still takes precedence: when set, no screenshots are returned regardless of `include_screenshot`.
- Defaults preserve existing behavior exactly (screenshot on, isometric view).
- `get_view` is unchanged apart from reusing the new shared `ViewName` literal alias.
- Verified end-to-end against a live FreeCAD instance with the addon: suppressed calls return text only, per-call view selection produces correctly oriented images, and the global flag still overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
