### PR TITLE
fix: handle errors in get_view_operation

### DIFF
--- a/src/freecad_mcp/operations/core.py
+++ b/src/freecad_mcp/operations/core.py
@@ -134,10 +134,14 @@ def get_view_operation(
     height: int | None = None,
     focus_object: str | None = None,
 ) -> ToolResponse:
-    screenshot = freecad.get_active_screenshot(view_name, width, height, focus_object)
-    if screenshot is not None:
-        return [ImageContent(type="image", data=screenshot, mimeType="image/png")]
-    return text_response("Cannot get screenshot in the current view type (such as TechDraw or Spreadsheet)")
+    try:
+        screenshot = freecad.get_active_screenshot(view_name, width, height, focus_object)
+        if screenshot is not None:
+            return [ImageContent(type="image", data=screenshot, mimeType="image/png")]
+        return text_response("Cannot get screenshot in the current view type (such as TechDraw or Spreadsheet)")
+    except Exception as e:
+        logger.error(f"Failed to get view: {str(e)}")
+        return text_response(f"Failed to get view: {str(e)}")
 
 
 def insert_part_from_library_operation(


### PR DESCRIPTION
get_view_operation was the only operation in operations/core.py calling its FreeCAD RPC bare. If get_active_screenshot raises an RPC or connection error, it propagated unhandled to the MCP client with no log line, unlike every sibling operation (create_object, execute_code, get_objects, and the rest), which wrap the call in try/except, log at error level, and return a text_response. server.py returns the operation result directly with no outer handler, so the operation has to own this.

This wraps the body in the same try/except the other operations use, so a failure logs and comes back as "Failed to get view: ..." instead of crashing the tool call. The None path (unsupported view types like TechDraw/Spreadsheet) and the ImageContent success path are unchanged.

I verified it with a stub connection: when get_active_screenshot raises, the function now returns the text_response instead of propagating; the None and success paths still return what they did before.