### PR TITLE
docs: remove contradictory SessionState.Label polling advice for execute_code_async

### DIFF
--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -116,8 +116,10 @@ class FreeCADRPC:
         """Start code execution in a background thread and return immediately.
 
         Use for long-running OCCT operations (fuse/cut/loft) that would otherwise
-        exceed the MCP timeout. The caller should poll a document object for
-        completion status (e.g. check SessionState.Label via get_object).
+        exceed the MCP timeout. Background code must not touch the FreeCAD
+        document or GUI; it should store results in a module-level Python
+        variable, which the caller later reads back (and applies to the
+        document) via execute_code on the GUI thread.
         """
         def _set_status(msg):
             dispatch_to_gui(lambda: FreeCADGui.getMainWindow().statusBar().showMessage(msg))

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -117,9 +117,12 @@ class FreeCADRPC:
 
         Use for long-running OCCT operations (fuse/cut/loft) that would otherwise
         exceed the MCP timeout. Background code must not touch the FreeCAD
-        document or GUI; it should store results in a module-level Python
-        variable, which the caller later reads back (and applies to the
-        document) via execute_code on the GUI thread.
+        document or GUI; it should keep an explicit job state in a module-level
+        variable (e.g. ``{"done": False, "result": None, "error": None}``) and
+        set ``done`` True with the result or error when it finishes. The caller
+        polls ``done`` via execute_code and only reads/applies the result once
+        it is True — reading after a fixed wait can pick up a missing or stale
+        result.
         """
         def _set_status(msg):
             dispatch_to_gui(lambda: FreeCADGui.getMainWindow().statusBar().showMessage(msg))

--- a/src/freecad_mcp/operations/core.py
+++ b/src/freecad_mcp/operations/core.py
@@ -117,11 +117,15 @@ def execute_code_async_operation(
         if res["success"]:
             return text_response(
                 "Code execution started in background.\n"
-                "The background code must not touch the FreeCAD document or GUI; "
-                "it should store results in a module-level Python variable. "
-                "After the expected computation time, read the variable back "
-                "(and apply results to the document) via execute_code. "
-                "FreeCAD's Report View will show output when done."
+                "The background code must not touch the FreeCAD document or GUI. "
+                "Give it an explicit completion flag in a module-level variable — "
+                "initialise e.g. `_job = {'done': False, 'result': None, "
+                "'error': None}`, and set `_job['done'] = True` (with the result "
+                "or the error) when it finishes. Poll `_job['done']` via "
+                "execute_code and only read `_job['result']` / apply it to the "
+                "document once done is True — do NOT wait a fixed time and read, "
+                "which can pick up a missing or stale result. FreeCAD's Report "
+                "View also shows output when done."
             )
         return text_response(f"Failed to start async execution: {res.get('error', 'unknown')}")
     except Exception as e:

--- a/src/freecad_mcp/operations/core.py
+++ b/src/freecad_mcp/operations/core.py
@@ -117,8 +117,10 @@ def execute_code_async_operation(
         if res["success"]:
             return text_response(
                 "Code execution started in background.\n"
-                "Use get_object to poll a document object for completion "
-                "(e.g. check SessionState.Label). "
+                "The background code must not touch the FreeCAD document or GUI; "
+                "it should store results in a module-level Python variable. "
+                "After the expected computation time, read the variable back "
+                "(and apply results to the document) via execute_code. "
                 "FreeCAD's Report View will show output when done."
             )
         return text_response(f"Failed to start async execution: {res.get('error', 'unknown')}")

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -104,7 +104,7 @@ def create_object(
     obj_type: str,
     obj_name: str,
     analysis_name: str | None = None,
-    obj_properties: dict[str, Any] = None,
+    obj_properties: dict[str, Any] | None = None,
 ) -> list[TextContent | ImageContent]:
     """Create a new object in FreeCAD.
     Object type is starts with "Part::" or "Draft::" or "PartDesign::" or "Fem::".

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -300,11 +300,15 @@ def execute_code_async(ctx: Context, code: str) -> list[TextContent]:
 
     Typical usage pattern:
     1. Fetch shapes into local variables first (via execute_code on the GUI thread).
-    2. Store intermediate results in a module-level Python variable (not in the
-       FreeCAD document) so execute_code can read them later.
+    2. Have the background code keep an explicit job state in a module-level
+       variable (not in the FreeCAD document), e.g.
+       ``_job = {"done": False, "result": None, "error": None}``, and set
+       ``_job["done"] = True`` with the result (or the error) when it finishes.
     3. Run the heavy computation via execute_code_async.
-    4. After the expected computation time has elapsed, apply results to the
-       document via execute_code (which runs on the GUI thread).
+    4. Poll ``_job["done"]`` via execute_code and, only once it is True, read
+       ``_job["result"]`` and apply it to the document via execute_code (which
+       runs on the GUI thread). Do not wait a fixed time and then read — the
+       result may be missing or stale if the computation has not finished.
 
     Args:
         code: Background-safe Python code to execute.


### PR DESCRIPTION
## Problem

The docstring fix in 6ae5ddf removed the "poll SessionState.Label" pattern from `server.py`, but the same contradictory guidance survived in two other places:

- `addon/FreeCADMCP/rpc_server/rpc_server.py` — `execute_code_async` docstring
- `src/freecad_mcp/operations/core.py` — the user-facing response text returned to the LLM client

Both tell the client to poll a **document object** for completion — but the same tool's documentation (correctly) forbids background code from touching the FreeCAD document. An LLM following the tool descriptions verbatim receives contradictory instructions.

## Fix

Replace the stale advice with the module-level-variable pattern already documented in `server.py`: background code stores results in a module variable; the caller reads them back (and applies them to the document) via `execute_code` on the GUI thread.

Also fixes a typing nit: `obj_properties: dict[str, Any] = None` → `dict[str, Any] | None = None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01715r6q45BLsEFsYyV1sYba