### PR TITLE
test: add unit tests for pure addon modules + CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv run pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+.venv/
+.pytest_cache/

--- a/addon/FreeCADMCP/rpc_server/serialize.py
+++ b/addon/FreeCADMCP/rpc_server/serialize.py
@@ -1,5 +1,4 @@
 import FreeCAD as App
-import json
 
 
 def _get_optional_app_type(name: str) -> type | tuple[type, ...] | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,14 @@ dependencies = [
 [project.scripts]
 freecad-mcp = "freecad_mcp.server:main"
 
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.hatch.build.targets.sdist]
 exclude = ["assets", "results"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,71 @@
+"""Shared test setup: stub the FreeCAD module and make the addon importable.
+
+The addon modules under ``addon/FreeCADMCP/rpc_server`` import ``FreeCAD``
+at module level. Outside a running FreeCAD there is no such module, so a
+minimal stub is installed into ``sys.modules`` before any addon import.
+Only the attributes the pure-Python modules actually touch are stubbed.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+ADDON_DIR = Path(__file__).resolve().parent.parent / "addon" / "FreeCADMCP"
+
+
+def _install_freecad_stub() -> types.ModuleType:
+    if "FreeCAD" in sys.modules:
+        return sys.modules["FreeCAD"]
+
+    fc = types.ModuleType("FreeCAD")
+
+    class Console:
+        messages: list = []
+
+        @classmethod
+        def PrintMessage(cls, msg):
+            cls.messages.append(("message", msg))
+
+        @classmethod
+        def PrintWarning(cls, msg):
+            cls.messages.append(("warning", msg))
+
+        @classmethod
+        def PrintError(cls, msg):
+            cls.messages.append(("error", msg))
+
+    class Vector:
+        def __init__(self, x=0.0, y=0.0, z=0.0):
+            self.x, self.y, self.z = x, y, z
+
+    class Rotation:
+        def __init__(self, axis=None, angle=0.0):
+            self.Axis = axis if axis is not None else Vector(0, 0, 1)
+            self.Angle = angle
+
+    class Placement:
+        def __init__(self, base=None, rotation=None):
+            self.Base = base if base is not None else Vector()
+            self.Rotation = rotation if rotation is not None else Rotation()
+
+    class Document:
+        pass
+
+    class DocumentObject:
+        pass
+
+    fc.Console = Console
+    fc.Vector = Vector
+    fc.Rotation = Rotation
+    fc.Placement = Placement
+    fc.Document = Document
+    fc.DocumentObject = DocumentObject
+    fc.getUserAppDataDir = lambda: ""
+    sys.modules["FreeCAD"] = fc
+    return fc
+
+
+_install_freecad_stub()
+
+if str(ADDON_DIR) not in sys.path:
+    sys.path.insert(0, str(ADDON_DIR))

--- a/tests/test_ip_filter.py
+++ b/tests/test_ip_filter.py
@@ -1,0 +1,84 @@
+import ipaddress
+
+from rpc_server.ip_filter import _parse_allowed_ips, validate_allowed_ips
+
+
+class TestValidateAllowedIps:
+    def test_single_ipv4(self):
+        valid, errors = validate_allowed_ips("127.0.0.1")
+        assert valid == ["127.0.0.1"]
+        assert errors == []
+
+    def test_cidr_subnet(self):
+        valid, errors = validate_allowed_ips("192.168.1.0/24")
+        assert valid == ["192.168.1.0/24"]
+        assert errors == []
+
+    def test_ipv6(self):
+        valid, errors = validate_allowed_ips("::1")
+        assert valid == ["::1"]
+        assert errors == []
+
+    def test_multiple_entries_with_spaces(self):
+        valid, errors = validate_allowed_ips("127.0.0.1, 192.168.1.0/24 , 10.0.0.5")
+        assert valid == ["127.0.0.1", "192.168.1.0/24", "10.0.0.5"]
+        assert errors == []
+
+    def test_empty_string(self):
+        valid, errors = validate_allowed_ips("")
+        assert valid == []
+        assert errors
+
+    def test_whitespace_only(self):
+        valid, errors = validate_allowed_ips("   ")
+        assert valid == []
+        assert errors
+
+    def test_leading_comma(self):
+        valid, errors = validate_allowed_ips(",127.0.0.1")
+        assert valid == []
+        assert errors
+
+    def test_trailing_comma(self):
+        valid, errors = validate_allowed_ips("127.0.0.1,")
+        assert valid == []
+        assert errors
+
+    def test_double_comma(self):
+        valid, errors = validate_allowed_ips("127.0.0.1,,10.0.0.5")
+        assert valid == []
+        assert errors
+
+    def test_mixed_valid_and_invalid(self):
+        valid, errors = validate_allowed_ips("127.0.0.1,not-an-ip")
+        assert valid == ["127.0.0.1"]
+        assert len(errors) == 1
+        assert "not-an-ip" in errors[0]
+
+    def test_hostname_rejected(self):
+        valid, errors = validate_allowed_ips("localhost")
+        assert valid == []
+        assert errors
+
+
+class TestParseAllowedIps:
+    def test_returns_networks(self):
+        networks = _parse_allowed_ips("127.0.0.1, 192.168.1.0/24")
+        assert networks == [
+            ipaddress.ip_network("127.0.0.1"),
+            ipaddress.ip_network("192.168.1.0/24"),
+        ]
+
+    def test_skips_invalid_entries(self):
+        networks = _parse_allowed_ips("127.0.0.1,bogus")
+        assert networks == [ipaddress.ip_network("127.0.0.1")]
+
+    def test_host_bits_tolerated(self):
+        # strict=False: a host address with a prefix is normalised, not rejected
+        networks = _parse_allowed_ips("192.168.1.5/24")
+        assert networks == [ipaddress.ip_network("192.168.1.0/24")]
+
+    def test_membership(self):
+        networks = _parse_allowed_ips("192.168.1.0/24")
+        assert ipaddress.ip_address("192.168.1.77") in networks[0]
+        assert ipaddress.ip_address("10.0.0.1") not in networks[0]

--- a/tests/test_property_mapper.py
+++ b/tests/test_property_mapper.py
@@ -1,0 +1,56 @@
+import pytest
+
+from rpc_server.property_mapper import _to_shape_color, parse_reference_entry
+
+
+class TestParseReferenceEntry:
+    def test_documented_dict_form(self):
+        assert parse_reference_entry({"object_name": "Box", "face": "Face1"}) == ("Box", "Face1")
+
+    def test_legacy_dict_keys(self):
+        assert parse_reference_entry({"Object": "Box", "Face": "Face1"}) == ("Box", "Face1")
+
+    def test_dict_without_face(self):
+        assert parse_reference_entry({"object_name": "Box"}) == ("Box", None)
+
+    def test_dict_missing_object_name_raises(self):
+        with pytest.raises(ValueError, match="object_name"):
+            parse_reference_entry({"face": "Face1"})
+
+    def test_legacy_pair_list(self):
+        assert parse_reference_entry(["Box", "Face1"]) == ("Box", "Face1")
+
+    def test_legacy_pair_tuple(self):
+        assert parse_reference_entry(("Box", "Face1")) == ("Box", "Face1")
+
+    def test_wrong_length_list_raises(self):
+        with pytest.raises(ValueError, match="Invalid reference entry"):
+            parse_reference_entry(["Box", "Face1", "extra"])
+
+    def test_scalar_raises(self):
+        with pytest.raises(ValueError, match="Invalid reference entry"):
+            parse_reference_entry("Box")
+
+
+class TestToShapeColor:
+    def test_rgb_gets_default_alpha(self):
+        assert _to_shape_color([0.5, 0.5, 0.5]) == (0.5, 0.5, 0.5, 1.0)
+
+    def test_rgba_passthrough(self):
+        assert _to_shape_color([0.1, 0.2, 0.3, 0.4]) == (0.1, 0.2, 0.3, 0.4)
+
+    def test_tuple_input(self):
+        assert _to_shape_color((1, 0, 0)) == (1.0, 0.0, 0.0, 1.0)
+
+    def test_ints_coerced_to_float(self):
+        result = _to_shape_color([1, 1, 1, 1])
+        assert result == (1.0, 1.0, 1.0, 1.0)
+        assert all(isinstance(c, float) for c in result)
+
+    def test_wrong_length_raises(self):
+        with pytest.raises(ValueError, match="ShapeColor"):
+            _to_shape_color([0.5, 0.5])
+
+    def test_non_sequence_raises(self):
+        with pytest.raises(ValueError, match="ShapeColor"):
+            _to_shape_color("red")

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,61 @@
+import FreeCAD as App
+
+from rpc_server.serialize import serialize_value
+
+
+class TestSerializeValue:
+    def test_int_passthrough(self):
+        assert serialize_value(42) == 42
+
+    def test_float_passthrough(self):
+        assert serialize_value(3.14) == 3.14
+
+    def test_str_passthrough(self):
+        assert serialize_value("hello") == "hello"
+
+    def test_bool_passthrough(self):
+        assert serialize_value(True) is True
+
+    def test_vector(self):
+        vec = App.Vector(1.0, 2.0, 3.0)
+        assert serialize_value(vec) == {"x": 1.0, "y": 2.0, "z": 3.0}
+
+    def test_rotation(self):
+        rot = App.Rotation(App.Vector(0, 0, 1), 45.0)
+        assert serialize_value(rot) == {
+            "Axis": {"x": 0, "y": 0, "z": 1},
+            "Angle": 45.0,
+        }
+
+    def test_placement_nested(self):
+        placement = App.Placement(
+            App.Vector(10.0, 20.0, 0.0),
+            App.Rotation(App.Vector(0, 0, 1), 90.0),
+        )
+        assert serialize_value(placement) == {
+            "Base": {"x": 10.0, "y": 20.0, "z": 0.0},
+            "Rotation": {"Axis": {"x": 0, "y": 0, "z": 1}, "Angle": 90.0},
+        }
+
+    def test_list_of_scalars(self):
+        assert serialize_value([1, "two", 3.0]) == [1, "two", 3.0]
+
+    def test_tuple_becomes_list(self):
+        assert serialize_value((1, 2)) == [1, 2]
+
+    def test_list_of_vectors(self):
+        vecs = [App.Vector(1, 0, 0), App.Vector(0, 1, 0)]
+        assert serialize_value(vecs) == [
+            {"x": 1, "y": 0, "z": 0},
+            {"x": 0, "y": 1, "z": 0},
+        ]
+
+    def test_unknown_object_falls_back_to_str(self):
+        class Custom:
+            def __str__(self):
+                return "custom-repr"
+
+        assert serialize_value(Custom()) == "custom-repr"
+
+    def test_none_falls_back_to_str(self):
+        assert serialize_value(None) == "None"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,57 @@
+import json
+import sys
+
+import pytest
+
+from rpc_server import settings as settings_mod
+from rpc_server.settings import _DEFAULT_SETTINGS, load_settings, save_settings
+
+
+@pytest.fixture
+def settings_dir(tmp_path, monkeypatch):
+    """Point the FreeCAD stub's user app data dir at a temp directory."""
+    monkeypatch.setattr(
+        sys.modules["FreeCAD"], "getUserAppDataDir", lambda: str(tmp_path)
+    )
+    return tmp_path
+
+
+class TestLoadSettings:
+    def test_missing_file_returns_defaults(self, settings_dir):
+        assert load_settings() == _DEFAULT_SETTINGS
+
+    def test_missing_file_returns_copy_not_shared_dict(self, settings_dir):
+        settings = load_settings()
+        settings["remote_enabled"] = True
+        assert _DEFAULT_SETTINGS["remote_enabled"] is False
+
+    def test_corrupt_file_returns_defaults(self, settings_dir):
+        (settings_dir / "freecad_mcp_settings.json").write_text("{not json!", encoding="utf-8")
+        assert load_settings() == _DEFAULT_SETTINGS
+
+    def test_partial_file_merged_with_defaults(self, settings_dir):
+        (settings_dir / "freecad_mcp_settings.json").write_text(
+            json.dumps({"remote_enabled": True}), encoding="utf-8"
+        )
+        settings = load_settings()
+        assert settings["remote_enabled"] is True
+        assert settings["allowed_ips"] == _DEFAULT_SETTINGS["allowed_ips"]
+        assert settings["auto_start_rpc"] == _DEFAULT_SETTINGS["auto_start_rpc"]
+
+    def test_unknown_keys_preserved(self, settings_dir):
+        (settings_dir / "freecad_mcp_settings.json").write_text(
+            json.dumps({"future_key": 123}), encoding="utf-8"
+        )
+        assert load_settings()["future_key"] == 123
+
+
+class TestSaveSettings:
+    def test_roundtrip(self, settings_dir):
+        settings = dict(_DEFAULT_SETTINGS)
+        settings["allowed_ips"] = "192.168.1.0/24"
+        save_settings(settings)
+        assert load_settings() == settings
+
+    def test_writes_expected_filename(self, settings_dir):
+        save_settings(dict(_DEFAULT_SETTINGS))
+        assert (settings_dir / "freecad_mcp_settings.json").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -66,11 +66,16 @@ wheels = [
 
 [[package]]
 name = "freecad-mcp"
-version = "0.1.17"
+version = "0.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "validators" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -78,6 +83,9 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.12.2" },
     { name = "validators", specifier = ">=0.34.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
 
 [[package]]
 name = "h11"
@@ -132,6 +140,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -211,6 +228,24 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -287,6 +322,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

The project had no tests. This adds 48 unit tests for the addon's pure-Python modules, runnable outside FreeCAD via a minimal `FreeCAD` stub injected in `tests/conftest.py`:

- `test_ip_filter.py` — IP/CIDR validation: valid entries, malformed lists, mixed valid+invalid, IPv6, `strict=False` normalisation, network membership
- `test_property_mapper.py` — `References` entry parsing (documented dict form, legacy keys, legacy pair form, error cases) and ShapeColor normalisation (RGB→RGBA, coercion, rejects)
- `test_serialize.py` — `serialize_value` for scalars, Vector/Rotation/Placement, nested lists, fallback-to-str
- `test_settings.py` — defaults on missing/corrupt file, merge of missing keys, unknown-key preservation, save/load roundtrip

A GitHub Actions workflow runs pytest on Python 3.12/3.13 via uv on every PR.

Also drops an unused `json` import in `serialize.py` and gitignores `.venv/`/`.pytest_cache/`.

## Why

Regressions in these modules (e.g. the serialize AttributeError fixed in #67, the RGB ShapeColor fix in #66) currently surface only in users' FreeCAD sessions. The pure modules are trivially testable — this gives future PRs a safety net at zero runtime cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01715r6q45BLsEFsYyV1sYba