### PR TITLE
fix: prevent heartbeat timer chains from leaking across server restarts

### DIFF
--- a/addon/FreeCADMCP/rpc_server/gui_dispatch.py
+++ b/addon/FreeCADMCP/rpc_server/gui_dispatch.py
@@ -106,7 +106,7 @@ def process_gui_tasks() -> None:
 
     Rescheduling is owned by ``_heartbeat_tick``; this function only drains.
     """
-    global _processing, _processing_since, _shutdown_requested
+    global _processing, _processing_since
     if _processing:
         return  # re-entrant call from processEvents inside a task; skip
 
@@ -136,10 +136,13 @@ def process_gui_tasks() -> None:
             while not _rpc_request_queue.empty():
                 task = _rpc_request_queue.get()
                 if task is _SHUTDOWN:
-                    # Safety net in case the sentinel is consumed by a wake-path
-                    # drain before request_shutdown's flag write is observed.
-                    _shutdown_requested = True
-                    return
+                    if _shutdown_requested:
+                        return  # server stopping; abandon the rest of this drain
+                    # Stale sentinel: the server was stopped and started again
+                    # before any drain consumed it (start_heartbeat cleared the
+                    # flag). Re-setting the flag here would kill the new
+                    # heartbeat chain — just skip it.
+                    continue
                 try:
                     task()
                 except Exception as e:

--- a/addon/FreeCADMCP/rpc_server/gui_dispatch.py
+++ b/addon/FreeCADMCP/rpc_server/gui_dispatch.py
@@ -16,8 +16,11 @@ Robustness and performance guarantees:
    only as a fallback.
 3. Mouse-button guard: ``process_gui_tasks`` skips the current tick while
    mouse buttons are held so MCP tasks cannot interrupt 3D navigation drags.
-4. Clean shutdown: the ``_SHUTDOWN`` sentinel sets a flag that suppresses the
-   ``finally`` reschedule, so ``stop_rpc_server`` actually stops the loop.
+4. Clean shutdown: ``request_shutdown`` sets a module flag (and posts the
+   ``_SHUTDOWN`` sentinel to break an in-progress drain). Heartbeat ticks
+   carry a generation id from ``start_heartbeat``; a tick whose id is stale
+   or that observes the shutdown flag exits without rescheduling, so
+   stop/start cycles can never stack multiple live heartbeat chains.
 5. Exception isolation: exceptions inside a task are caught, logged, and
    returned as error strings; they never kill the dispatch loop.
 """
@@ -36,6 +39,8 @@ _rpc_request_queue: "queue.Queue[Any]" = queue.Queue()
 _SHUTDOWN = object()
 _processing = False  # re-entrancy guard: True while process_gui_tasks is draining
 _processing_since: float = 0.0  # wall-clock time when _processing became True
+_chain_id = 0  # heartbeat generation; bumped by start_heartbeat to kill stale chains
+_shutdown_requested = False  # set by request_shutdown; suppresses heartbeat rescheduling
 
 
 class _WakeSignal(QtCore.QObject):
@@ -55,7 +60,7 @@ class _WakeSignal(QtCore.QObject):
         self._sig.emit()
 
     def _on_wake(self) -> None:
-        process_gui_tasks(reschedule=False)
+        process_gui_tasks()
 
 
 _waker: "_WakeSignal | None" = None
@@ -91,22 +96,20 @@ def _flush_gui_events(delay_ms: int = 20) -> None:
         app.processEvents(flags, delay_ms)
 
 
-def process_gui_tasks(reschedule: bool = True) -> None:
-    """Drain queued GUI-thread callables and optionally reschedule.
+def process_gui_tasks() -> None:
+    """Drain queued GUI-thread callables.
 
     Skips the current tick when any mouse button is held (e.g., 3D navigation
     drag) or when already executing a task (re-entrancy guard). The guard
     prevents ``doc.recompute()`` or ``processEvents()`` inside a task from
     triggering a nested ``process_gui_tasks`` call that corrupts FreeCAD state.
 
-    ``reschedule=False`` is used by the immediate-wake path so it does not
-    start a second heartbeat chain alongside the existing 500 ms one.
+    Rescheduling is owned by ``_heartbeat_tick``; this function only drains.
     """
-    global _processing, _processing_since
+    global _processing, _processing_since, _shutdown_requested
     if _processing:
         return  # re-entrant call from processEvents inside a task; skip
 
-    shutdown = False
     try:
         if _rpc_request_queue.empty():
             return  # nothing queued; skip cursor/status-bar churn on idle heartbeat ticks
@@ -133,7 +136,9 @@ def process_gui_tasks(reschedule: bool = True) -> None:
             while not _rpc_request_queue.empty():
                 task = _rpc_request_queue.get()
                 if task is _SHUTDOWN:
-                    shutdown = True
+                    # Safety net in case the sentinel is consumed by a wake-path
+                    # drain before request_shutdown's flag write is observed.
+                    _shutdown_requested = True
                     return
                 try:
                     task()
@@ -149,12 +154,37 @@ def process_gui_tasks(reschedule: bool = True) -> None:
                 status_bar.clearMessage()
     finally:
         _processing = False
-        if not shutdown and reschedule:
-            QtCore.QTimer.singleShot(500, process_gui_tasks)
+
+
+def _heartbeat_tick(chain_id: int) -> None:
+    """One 500 ms fallback tick. Only the chain matching the current
+    generation id reschedules itself; stale chains (from a previous
+    start/stop cycle) and post-shutdown ticks die here.
+    """
+    if chain_id != _chain_id or _shutdown_requested:
+        return
+    process_gui_tasks()
+    if chain_id == _chain_id and not _shutdown_requested:
+        QtCore.QTimer.singleShot(500, lambda: _heartbeat_tick(chain_id))
+
+
+def start_heartbeat() -> None:
+    """Start the 500 ms fallback heartbeat chain. Call from the GUI thread
+    on server start. Bumping the generation id invalidates any pending tick
+    from a previous chain, so repeated stop/start cycles keep exactly one
+    live chain.
+    """
+    global _chain_id, _shutdown_requested
+    _shutdown_requested = False
+    _chain_id += 1
+    chain_id = _chain_id
+    QtCore.QTimer.singleShot(500, lambda: _heartbeat_tick(chain_id))
 
 
 def request_shutdown() -> None:
-    """Post the sentinel so the next dispatch tick exits without rescheduling."""
+    """Stop the heartbeat and post the sentinel to break an in-progress drain."""
+    global _shutdown_requested
+    _shutdown_requested = True
     _rpc_request_queue.put(_SHUTDOWN)
 
 

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -9,16 +9,14 @@ import tempfile
 import threading
 from typing import Any
 
-from PySide import QtCore
-
 from rpc_server.commands import register_commands, schedule_toggle_sync
 from rpc_server.fem_executor import run_fem_analysis as _run_fem_analysis
 from rpc_server.gui_dispatch import (
     cleanup_waker,
     dispatch_to_gui,
     init_waker,
-    process_gui_tasks,
     request_shutdown,
+    start_heartbeat,
 )
 from rpc_server.ip_filter import FilteredXMLRPCServer, validate_allowed_ips
 from rpc_server.object_factory import create_object_gui
@@ -365,7 +363,7 @@ def start_rpc_server(port=9875):
     rpc_server_thread.start()
 
     init_waker()
-    QtCore.QTimer.singleShot(500, process_gui_tasks)
+    start_heartbeat()
 
     msg = f"RPC Server started at {host}:{port}."
     if remote_enabled:


### PR DESCRIPTION
## Problem

The 500 ms fallback heartbeat reschedules itself from `process_gui_tasks`' `finally` block, suppressed only when **that same invocation** consumes the `_SHUTDOWN` sentinel.

Failure scenario:
1. `stop_rpc_server` posts the sentinel.
2. A concurrent `dispatch_to_gui` wake (`reschedule=False`) drains the queue and consumes the sentinel.
3. The heartbeat chain's already-pending `QTimer` fires later, sees an empty queue, and reschedules — the chain survives shutdown **forever**.
4. Each stop/start cycle stacks one more immortal chain.

## Fix

Rescheduling moves into a dedicated `_heartbeat_tick(chain_id)`:

- `start_heartbeat()` bumps a generation id; any pending tick from a previous chain sees a stale id and dies without rescheduling.
- `request_shutdown()` sets a module-level `_shutdown_requested` flag (in addition to posting the sentinel, which still breaks an in-progress drain), so the current chain stops regardless of which path consumed the sentinel.

Exactly one chain is live after any sequence of start/stop cycles. `process_gui_tasks` now only drains; `start_rpc_server` calls `start_heartbeat()` instead of scheduling a raw singleShot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01715r6q45BLsEFsYyV1sYba