### PR TITLE
fix: run execute_code in a dedicated namespace instead of module globals

### DIFF
--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -31,6 +31,17 @@ from rpc_server.view_manager import save_active_screenshot
 rpc_server_thread = None
 rpc_server_instance = None
 
+# Persistent namespace for execute_code / execute_code_async. A dedicated dict
+# (instead of this module's globals()) keeps user code from shadowing server
+# internals like dispatch_to_gui while preserving the documented pattern of
+# sharing module-level variables between successive calls.
+_EXEC_NAMESPACE: dict[str, Any] = {
+    "FreeCAD": FreeCAD,
+    "App": FreeCAD,
+    "FreeCADGui": FreeCADGui,
+    "Gui": FreeCADGui,
+}
+
 
 def _ok(res) -> bool:
     """True when a GUI-thread handler returned success."""
@@ -131,7 +142,7 @@ class FreeCADRPC:
             # GUI thread and other concurrent work. Background code should report
             # via FreeCAD.Console (which is thread-safe) instead.
             try:
-                exec(code, globals())
+                exec(code, _EXEC_NAMESPACE)
                 FreeCAD.Console.PrintMessage("Async code execution completed.\n")
             except Exception as e:
                 import traceback as _tb
@@ -157,7 +168,7 @@ class FreeCADRPC:
 
         def task():
             with contextlib.redirect_stdout(output_buffer):
-                exec(code, globals())
+                exec(code, _EXEC_NAMESPACE)
             return True
 
         res = dispatch_to_gui(task, timeout=self.EXECUTE_CODE_TIMEOUT)


### PR DESCRIPTION
## Problem

`execute_code` and `execute_code_async` run `exec(code, globals())` — user code executes directly inside the `rpc_server` module's namespace. Code that assigns to names like `dispatch_to_gui`, `FreeCAD`, or any RPC handler silently rebinds the server's own internals and bricks the running server until FreeCAD restarts. Easy to hit accidentally (e.g. a script defining its own `serialize_object` helper).

## Fix

Both tools now share a persistent `_EXEC_NAMESPACE` dict seeded with `FreeCAD`/`App`/`FreeCADGui`/`Gui`. The documented cross-call pattern — an async worker stores a result in a module-level variable, a later `execute_code` applies it to the document — still works (same dict), but server internals are no longer reachable from user code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01715r6q45BLsEFsYyV1sYba