### PR TITLE
feat: optional shared-secret token auth for the RPC server

### DIFF
--- a/addon/FreeCADMCP/InitGui.py
+++ b/addon/FreeCADMCP/InitGui.py
@@ -22,6 +22,7 @@ class FreeCADMCPAddonWorkbench(Workbench):
             "Toggle_Auto_Start",
             "Toggle_Remote_Connections",
             "Configure_Allowed_IPs",
+            "Set_Auth_Token",
         ]
         self.appendToolbar("FreeCAD MCP", commands)
         self.appendMenu("FreeCAD MCP", commands)

--- a/addon/FreeCADMCP/rpc_server/commands.py
+++ b/addon/FreeCADMCP/rpc_server/commands.py
@@ -61,6 +61,12 @@ class ToggleRemoteConnectionsCommand:
             FreeCAD.Console.PrintMessage(
                 f"Remote connections enabled. Allowed IPs: {allowed_ips}\n"
             )
+            if not settings.get("auth_token", ""):
+                FreeCAD.Console.PrintWarning(
+                    "Remote connections have no auth token configured — anyone on "
+                    "an allowed IP can execute code in FreeCAD. Set one via "
+                    "'Set Auth Token' in the FreeCAD MCP menu.\n"
+                )
         else:
             FreeCAD.Console.PrintMessage("Remote connections disabled.\n")
 
@@ -123,6 +129,44 @@ class ConfigureAllowedIPsCommand:
         return True
 
 
+class SetAuthTokenCommand:
+    def GetResources(self):
+        return {
+            "MenuText": "Set Auth Token",
+            "ToolTip": "Set the shared-secret token clients must present to connect. Blank disables authentication.",
+        }
+
+    def Activated(self):
+        from . import rpc_server
+        settings = load_settings()
+        current = settings.get("auth_token", "")
+        text, ok = QtWidgets.QInputDialog.getText(
+            None,
+            "Auth Token",
+            "Enter the auth token clients must present (leave blank to disable\n"
+            "authentication). The MCP server passes it via --auth-token or the\n"
+            "FREECAD_MCP_TOKEN environment variable.",
+            QtWidgets.QLineEdit.Normal,
+            current,
+        )
+        if not ok:
+            FreeCAD.Console.PrintMessage("Auth token not changed.\n")
+            return
+        settings["auth_token"] = text.strip()
+        save_settings(settings)
+        if settings["auth_token"]:
+            FreeCAD.Console.PrintMessage("Auth token set — clients must authenticate.\n")
+        else:
+            FreeCAD.Console.PrintMessage("Auth token cleared — authentication disabled.\n")
+        if rpc_server.rpc_server_instance:
+            FreeCAD.Console.PrintMessage(
+                "Restart the RPC server for changes to take effect.\n"
+            )
+
+    def IsActive(self):
+        return True
+
+
 class ToggleAutoStartCommand:
     def GetResources(self):
         return {
@@ -155,6 +199,7 @@ def register_commands() -> None:
     FreeCADGui.addCommand("Toggle_Auto_Start", ToggleAutoStartCommand())
     FreeCADGui.addCommand("Toggle_Remote_Connections", ToggleRemoteConnectionsCommand())
     FreeCADGui.addCommand("Configure_Allowed_IPs", ConfigureAllowedIPsCommand())
+    FreeCADGui.addCommand("Set_Auth_Token", SetAuthTokenCommand())
 
 
 # Map command objectName -> settings key. Matching on objectName rather than

--- a/addon/FreeCADMCP/rpc_server/ip_filter.py
+++ b/addon/FreeCADMCP/rpc_server/ip_filter.py
@@ -1,17 +1,60 @@
-"""IP-filtered XML-RPC server and helpers for parsing allowed IP/subnet lists."""
+"""IP-filtered, optionally token-authenticated XML-RPC server and helpers."""
 
+import base64
+import hmac
 import ipaddress
 import re
-from xmlrpc.server import SimpleXMLRPCServer
+from xmlrpc.server import SimpleXMLRPCRequestHandler, SimpleXMLRPCServer
 
 import FreeCAD
 
 
-class FilteredXMLRPCServer(SimpleXMLRPCServer):
-    """XML-RPC server that filters connections by allowed IP addresses/subnets."""
+def authorization_ok(header_value: str, token: str) -> bool:
+    """Check an ``Authorization`` header against the configured token.
 
-    def __init__(self, addr, allowed_ips_str="127.0.0.1", **kwargs):
+    Accepts ``Bearer <token>`` and HTTP Basic (token in the password field,
+    username ignored) so stdlib clients can use ``http://:token@host:port``
+    URIs. Comparisons are constant-time.
+    """
+    if header_value.startswith("Bearer "):
+        supplied = header_value[len("Bearer "):].strip()
+        return hmac.compare_digest(supplied, token)
+    if header_value.startswith("Basic "):
+        try:
+            decoded = base64.b64decode(header_value[len("Basic "):], validate=True).decode("utf-8")
+        except Exception:
+            return False
+        _, _, password = decoded.partition(":")
+        return hmac.compare_digest(password, token)
+    return False
+
+
+class TokenAuthRequestHandler(SimpleXMLRPCRequestHandler):
+    """Request handler that enforces the server's auth token when one is set."""
+
+    def parse_request(self):
+        if not super().parse_request():
+            return False
+        token = getattr(self.server, "auth_token", "")
+        if not token:
+            return True  # authentication disabled
+        if authorization_ok(self.headers.get("Authorization", ""), token):
+            return True
+        FreeCAD.Console.PrintWarning(
+            f"MCP RPC: Rejected unauthenticated request from {self.client_address[0]}\n"
+        )
+        self.send_error(401, "Unauthorized: valid auth token required")
+        return False
+
+
+class FilteredXMLRPCServer(SimpleXMLRPCServer):
+    """XML-RPC server that filters connections by allowed IP addresses/subnets
+    and (when a token is configured) requires an Authorization header."""
+
+    def __init__(self, addr, allowed_ips_str="127.0.0.1", auth_token="", **kwargs):
         self._allowed_networks = _parse_allowed_ips(allowed_ips_str)
+        self.auth_token = auth_token or ""
+        kwargs.setdefault("requestHandler", TokenAuthRequestHandler)
         super().__init__(addr, **kwargs)
 
     def verify_request(self, request, client_address):

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -344,14 +344,25 @@ def start_rpc_server(port=9875):
     settings = load_settings()
     remote_enabled = settings.get("remote_enabled", False)
     allowed_ips = settings.get("allowed_ips", "127.0.0.1")
+    auth_token = settings.get("auth_token", "")
 
     if remote_enabled:
         host = "0.0.0.0"
+        if not auth_token:
+            FreeCAD.Console.PrintWarning(
+                "MCP RPC: remote connections are enabled WITHOUT an auth token. "
+                "Anyone on an allowed IP can execute code in FreeCAD. "
+                "Set a token via 'Set Auth Token' in the FreeCAD MCP menu.\n"
+            )
     else:
         host = "127.0.0.1"
 
     rpc_server_instance = FilteredXMLRPCServer(
-        (host, port), allowed_ips_str=allowed_ips, allow_none=True, logRequests=False
+        (host, port),
+        allowed_ips_str=allowed_ips,
+        auth_token=auth_token,
+        allow_none=True,
+        logRequests=False,
     )
     rpc_server_instance.register_instance(FreeCADRPC())
 
@@ -359,6 +370,8 @@ def start_rpc_server(port=9875):
         FreeCAD.Console.PrintMessage(f"RPC Server started at {host}:{port}\n")
         if remote_enabled:
             FreeCAD.Console.PrintMessage(f"Remote connections enabled. Allowed IPs: {allowed_ips}\n")
+        if auth_token:
+            FreeCAD.Console.PrintMessage("Auth token required for all connections.\n")
         rpc_server_instance.serve_forever()
 
     rpc_server_thread = threading.Thread(target=server_loop, daemon=True)

--- a/addon/FreeCADMCP/rpc_server/settings.py
+++ b/addon/FreeCADMCP/rpc_server/settings.py
@@ -12,6 +12,7 @@ _DEFAULT_SETTINGS = {
     "remote_enabled": False,
     "allowed_ips": "127.0.0.1",
     "auto_start_rpc": False,
+    "auth_token": "",  # empty = authentication disabled
 }
 
 

--- a/src/freecad_mcp/freecad_client.py
+++ b/src/freecad_mcp/freecad_client.py
@@ -1,4 +1,5 @@
 import logging
+import urllib.parse
 import xmlrpc.client
 from typing import Any
 
@@ -24,8 +25,17 @@ class _TimeoutTransport(xmlrpc.client.Transport):
 
 
 class FreeCADConnection:
-    def __init__(self, host: str = "localhost", port: int = 9875, timeout: float = 150):
-        self._uri = f"http://{host}:{port}"
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 9875,
+        timeout: float = 150,
+        token: str | None = None,
+    ):
+        # A configured token travels as the password field of HTTP Basic auth
+        # (username empty), which xmlrpc.client extracts from the URI itself.
+        auth = f":{urllib.parse.quote(token, safe='')}@" if token else ""
+        self._uri = f"http://{auth}{host}:{port}"
         self._timeout = timeout
         self.server = self._make_proxy(timeout)
 
@@ -100,6 +110,7 @@ class FreeCADConnection:
         # The solver blocks the RPC response for up to `timeout` seconds, so the
         # socket must outlast it. The default 150 s transport timeout would abort
         # any solve longer than that even though the addon is still working.
-        # Use a dedicated proxy whose socket timeout exceeds the solver timeout.
-        proxy = self._make_proxy(max(self._timeout, timeout + 30))
-        return proxy.run_fem_analysis(doc_name, analysis_name, timeout)
+        # Use a dedicated proxy whose socket timeout exceeds the solver timeout;
+        # close it when done so the one-off HTTP connection is not left cached.
+        with self._make_proxy(max(self._timeout, timeout + 30)) as proxy:
+            return proxy.run_fem_analysis(doc_name, analysis_name, timeout)

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -66,7 +66,9 @@ mcp = FastMCP(
 def get_freecad_connection() -> FreeCADConnection:
     """Get or create a persistent FreeCAD connection"""
     if state.freecad_connection is None:
-        state.freecad_connection = FreeCADConnection(host=state.rpc_host, port=9875)
+        state.freecad_connection = FreeCADConnection(
+            host=state.rpc_host, port=9875, token=state.auth_token
+        )
         if not state.freecad_connection.ping():
             logger.error("Failed to ping FreeCAD")
             state.freecad_connection = None
@@ -524,13 +526,23 @@ def _validate_host(value: str) -> str:
 def main():
     """Run the MCP server"""
     import argparse
+    import os
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--only-text-feedback", action="store_true", help="Only return text feedback")
     parser.add_argument("--host", type=_validate_host, default="localhost", help="Host address of the FreeCAD RPC server to connect to (default: localhost)")
+    parser.add_argument(
+        "--auth-token",
+        default=None,
+        help="Auth token the FreeCAD RPC server requires (falls back to the "
+        "FREECAD_MCP_TOKEN environment variable; omit if the addon has no token set)",
+    )
     args = parser.parse_args()
     state.only_text_feedback = args.only_text_feedback
     state.rpc_host = args.host
+    state.auth_token = args.auth_token or os.environ.get("FREECAD_MCP_TOKEN") or None
     logger.info(f"Only text feedback: {state.only_text_feedback}")
     logger.info(f"Connecting to FreeCAD RPC server at: {state.rpc_host}")
+    if state.auth_token:
+        logger.info("Auth token configured for RPC connection")
     mcp.run()

--- a/src/freecad_mcp/server_state.py
+++ b/src/freecad_mcp/server_state.py
@@ -7,4 +7,5 @@ from .freecad_client import FreeCADConnection
 class ServerState:
     only_text_feedback: bool = False
     rpc_host: str = "localhost"
+    auth_token: str | None = None
     freecad_connection: FreeCADConnection | None = None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,45 @@
+import base64
+
+from rpc_server.ip_filter import authorization_ok
+
+
+TOKEN = "s3cret-token"
+
+
+def _basic(user: str, password: str) -> str:
+    return "Basic " + base64.b64encode(f"{user}:{password}".encode()).decode()
+
+
+class TestAuthorizationOk:
+    def test_bearer_match(self):
+        assert authorization_ok(f"Bearer {TOKEN}", TOKEN) is True
+
+    def test_bearer_mismatch(self):
+        assert authorization_ok("Bearer wrong", TOKEN) is False
+
+    def test_bearer_trailing_whitespace_tolerated(self):
+        assert authorization_ok(f"Bearer {TOKEN}  ", TOKEN) is True
+
+    def test_basic_password_field_match(self):
+        # stdlib xmlrpc clients send http://:token@host as Basic with empty user
+        assert authorization_ok(_basic("", TOKEN), TOKEN) is True
+
+    def test_basic_username_ignored(self):
+        assert authorization_ok(_basic("anyuser", TOKEN), TOKEN) is True
+
+    def test_basic_wrong_password(self):
+        assert authorization_ok(_basic("", "wrong"), TOKEN) is False
+
+    def test_basic_invalid_base64(self):
+        assert authorization_ok("Basic !!!not-base64!!!", TOKEN) is False
+
+    def test_empty_header(self):
+        assert authorization_ok("", TOKEN) is False
+
+    def test_unknown_scheme(self):
+        assert authorization_ok(f"Digest {TOKEN}", TOKEN) is False
+
+    def test_token_with_colon(self):
+        token = "with:colon"
+        # partition on the first colon keeps the rest as the password
+        assert authorization_ok(_basic("", token), token) is True


### PR DESCRIPTION
## Problem

With remote connections enabled, the RPC server binds `0.0.0.0` protected only by the IP allowlist — no authentication, plain HTTP. Since `execute_code` is arbitrary code execution by design, anyone on an allowed subnet has full code execution in the FreeCAD process. IP filtering is not authentication.

## Fix

**Addon**: new `auth_token` setting (empty = disabled → fully backward compatible). When set, a `TokenAuthRequestHandler` requires an `Authorization` header — `Bearer <token>`, or HTTP Basic with the token in the password field so stdlib `http://:token@host:port` URIs work — compared via `hmac.compare_digest`; failures get 401. A new **Set Auth Token** menu command manages the setting, and enabling remote connections without a token logs an explicit warning (as does server start).

**Client**: `FreeCADConnection` accepts a `token` and embeds it in the URI; the MCP server takes `--auth-token` or the `FREECAD_MCP_TOKEN` environment variable.

Includes `tests/test_auth.py` (10 cases: Bearer/Basic match & mismatch, username ignored, invalid base64, unknown scheme, token containing a colon). The test relies on the stub `conftest.py` from #85 and is inert until that lands — no shared files, no conflict either way.

Also closes the per-call FEM proxy when done so its one-off HTTP connection is not left cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01715r6q45BLsEFsYyV1sYba