### PR TITLE
fix: close the listening socket on stop and drain shutdown off the GUI thread

### DIFF
--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -30,6 +30,7 @@ from rpc_server.view_manager import save_active_screenshot
 
 rpc_server_thread = None
 rpc_server_instance = None
+_stop_thread = None  # drains shutdown off the GUI thread; see stop_rpc_server
 
 
 def _ok(res) -> bool:
@@ -341,6 +342,14 @@ def start_rpc_server(port=9875):
     if rpc_server_instance:
         return "RPC Server already running."
 
+    # A previous stop may still be draining an in-flight request off-thread;
+    # binding before its server_close() would hit the old socket.
+    if _stop_thread is not None and _stop_thread.is_alive():
+        _stop_thread.join(timeout=5.0)
+        if _stop_thread.is_alive():
+            return ("RPC Server is still stopping (a request is draining); "
+                    "try again in a few seconds.")
+
     settings = load_settings()
     remote_enabled = settings.get("remote_enabled", False)
     allowed_ips = settings.get("allowed_ips", "127.0.0.1")
@@ -374,19 +383,43 @@ def start_rpc_server(port=9875):
 
 
 def stop_rpc_server():
-    global rpc_server_instance, rpc_server_thread
+    global rpc_server_instance, rpc_server_thread, _stop_thread
 
-    if rpc_server_instance:
-        request_shutdown()
-        cleanup_waker()
-        rpc_server_instance.shutdown()
-        rpc_server_thread.join()
-        rpc_server_instance = None
-        rpc_server_thread = None
+    if not rpc_server_instance:
+        return "RPC Server was not running."
+
+    server = rpc_server_instance
+    thread = rpc_server_thread
+    rpc_server_instance = None
+    rpc_server_thread = None
+
+    request_shutdown()
+    cleanup_waker()
+
+    def _shutdown_and_close():
+        # shutdown() blocks until serve_forever drains the in-flight request,
+        # and that request may itself be waiting on dispatch_to_gui — running
+        # this on the GUI thread (menu command) froze the UI for up to the
+        # dispatch timeout. server_close() must always follow: without it the
+        # listening socket stays bound and Stop -> Start fails with
+        # EADDRINUSE (the restart the README asks for after changing Remote
+        # Connections or Allowed IPs).
+        try:
+            server.shutdown()
+            if thread is not None:
+                thread.join(timeout=10.0)
+                if thread.is_alive():
+                    FreeCAD.Console.PrintWarning(
+                        "MCP RPC: server thread still draining a request; "
+                        "socket closes when it finishes.\n"
+                    )
+        finally:
+            server.server_close()
         FreeCAD.Console.PrintMessage("RPC Server stopped.\n")
-        return "RPC Server stopped."
 
-    return "RPC Server was not running."
+    _stop_thread = threading.Thread(target=_shutdown_and_close, daemon=True)
+    _stop_thread.start()
+    return "RPC Server stopping…"
 
 
 register_commands()


### PR DESCRIPTION
## Problem

`stop_rpc_server` never calls `server_close()`, so the listening socket stays open after Stop. Because `SimpleXMLRPCServer` sets `allow_reuse_address`, the next Start does not fail loudly — it binds a second socket onto the same port while the dead one still holds the listen queue, so whether new connections reach the new server is undefined. This breaks the Stop → Start cycle the README asks users to perform after changing Remote Connections or Allowed IPs.

Separately, `shutdown()` blocks until `serve_forever` drains the in-flight request — and that request may itself be waiting on the GUI thread via `dispatch_to_gui`. Since the Stop menu command runs on the GUI thread, stopping during an in-flight request froze the UI for up to the dispatch timeout.

## Fix

- `stop_rpc_server` clears the globals immediately, then runs `shutdown()` → `join(timeout)` → `server_close()` on a small worker thread; the port is always released.
- `start_rpc_server` waits briefly for a still-draining stop before rebinding, so rapid Stop → Start cannot race the old socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01715r6q45BLsEFsYyV1sYba