### PR TITLE
fix: report FreeCAD's actual document/object names, not the requested ones

### DIFF
--- a/addon/FreeCADMCP/rpc_server/object_factory.py
+++ b/addon/FreeCADMCP/rpc_server/object_factory.py
@@ -12,11 +12,12 @@ import ObjectsFem
 from rpc_server.property_mapper import Object, set_object_property
 
 
-def _create_fem_mesh(doc: FreeCAD.Document, obj: Object) -> None:
+def _create_fem_mesh(doc: FreeCAD.Document, obj: Object):
     """Create a ``Fem::FemMeshGmsh`` and run Gmsh to populate it.
 
     Accepts both the FreeCAD 0.x and 1.x property names (``Part``/``Shape``,
     ``ElementSize{Max,Min}``/``CharacteristicLength{Max,Min}``).
+    Returns the created mesh object.
     """
     from femmesh.gmshtools import GmshTools
 
@@ -50,9 +51,10 @@ def _create_fem_mesh(doc: FreeCAD.Document, obj: Object) -> None:
     FreeCAD.Console.PrintMessage(
         f"FEM Mesh '{res.Name}' generated successfully in '{doc.Name}'.\n"
     )
+    return res
 
 
-def _create_fem_object(doc: FreeCAD.Document, obj: Object) -> None:
+def _create_fem_object(doc: FreeCAD.Document, obj: Object):
     """Create a ``Fem::*`` object via the appropriate ``ObjectsFem.makeXxx`` factory."""
     fem_make_methods = {
         "MaterialCommon": ObjectsFem.makeMaterialSolid,
@@ -72,21 +74,25 @@ def _create_fem_object(doc: FreeCAD.Document, obj: Object) -> None:
     )
     if obj.type != "Fem::AnalysisPython" and obj.analysis:
         getattr(doc, obj.analysis).addObject(res)
+    return res
 
 
-def _create_generic_object(doc: FreeCAD.Document, obj: Object) -> None:
+def _create_generic_object(doc: FreeCAD.Document, obj: Object):
     res = doc.addObject(obj.type, obj.name)
     set_object_property(doc, res, obj.properties)
     FreeCAD.Console.PrintMessage(
         f"{res.TypeId} '{res.Name}' added to '{doc.Name}' via RPC.\n"
     )
+    return res
 
 
 def create_object_gui(doc_name: str, obj: Object):
     """Create an object in ``doc_name`` according to ``obj.type``.
 
-    Returns ``True`` on success, or an error string on failure (matching the
-    legacy GUI-handler return contract).
+    Returns the created object's actual ``Name`` on success (FreeCAD
+    sanitises and de-duplicates requested names — ``Box`` may come back as
+    ``Box001`` — and every later get_object/edit_object call needs the real
+    one), or an error string on failure.
     """
     try:
         doc = FreeCAD.getDocument(doc_name)
@@ -100,13 +106,13 @@ def create_object_gui(doc_name: str, obj: Object):
                     "Fem::FemMeshGmsh requires an 'analysis_name' naming the "
                     "Fem::AnalysisPython container to add the mesh to."
                 )
-            _create_fem_mesh(doc, obj)
+            created = _create_fem_mesh(doc, obj)
         elif obj.type.startswith("Fem::"):
-            _create_fem_object(doc, obj)
+            created = _create_fem_object(doc, obj)
         else:
-            _create_generic_object(doc, obj)
+            created = _create_generic_object(doc, obj)
 
         doc.recompute()
-        return True
+        return {"success": True, "object_name": created.Name}
     except Exception as e:
         return str(e)

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -53,9 +53,13 @@ class FreeCADRPC:
         return True
 
     def create_document(self, name="New_Document"):
+        # The GUI handler reports the document's ACTUAL name — FreeCAD
+        # sanitises requested names ("My Doc" -> "My_Doc") and de-duplicates
+        # ("Doc" -> "Doc001"); reporting the requested name breaks every
+        # follow-up call that uses it.
         res = dispatch_to_gui(lambda: self._create_document_gui(name))
-        if _ok(res):
-            return {"success": True, "document_name": name}
+        if isinstance(res, dict) and res.get("success"):
+            return res
         return _err(res)
 
     def create_object(self, doc_name, obj_data: dict[str, Any]):
@@ -65,9 +69,11 @@ class FreeCADRPC:
             analysis=obj_data.get("Analysis", None),
             properties=obj_data.get("Properties", {}),
         )
+        # create_object_gui reports the created object's actual Name (see
+        # its docstring) — same sanitise/de-duplicate concern as documents.
         res = dispatch_to_gui(lambda: self._create_object_gui(doc_name, obj))
-        if _ok(res):
-            return {"success": True, "object_name": obj.name}
+        if isinstance(res, dict) and res.get("success"):
+            return res
         return _err(res)
 
     def edit_object(self, doc_name: str, obj_name: str, properties: dict[str, Any]) -> dict[str, Any]:
@@ -250,8 +256,8 @@ class FreeCADRPC:
     def _create_document_gui(self, name):
         doc = FreeCAD.newDocument(name)
         doc.recompute()
-        FreeCAD.Console.PrintMessage(f"Document '{name}' created via RPC.\n")
-        return True
+        FreeCAD.Console.PrintMessage(f"Document '{doc.Name}' created via RPC.\n")
+        return {"success": True, "document_name": doc.Name}
 
     def _create_object_gui(self, doc_name, obj: Object):
         return create_object_gui(doc_name, obj)


### PR DESCRIPTION
FreeCAD sanitises requested names (`My Doc` → `My_Doc`) and de-duplicates (`Box` → `Box001`), but `create_document`/`create_object` echoed the requested name back to the client. Every follow-up call an MCP client makes with that name — `get_object`, `edit_object`, generated `execute_code` — then targets a nonexistent or, worse, a different object.

The GUI handlers now return the created `Document.Name` / `DocumentObject.Name`, and the RPC layer passes them through. The client-side response text already prints `res['document_name']`/`res['object_name']`, so LLM clients see the real name with no client change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01715r6q45BLsEFsYyV1sYba