### PR TITLE
fix: stop misreporting every screenshot failure as a view-type problem

### DIFF
--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -222,9 +222,16 @@ class FreeCADRPC:
         os.close(fd)
 
         def task():
+            # Each failure logs its own reason: the RPC's None return is
+            # ambiguous by contract, and clients were blaming every failure
+            # on "wrong view type".
             try:
                 active_view = FreeCADGui.ActiveDocument.ActiveView
             except Exception:
+                FreeCAD.Console.PrintWarning(
+                    "MCP RPC: screenshot requested but no document/view is "
+                    "active (open or create a document first)\n"
+                )
                 return False
             if active_view is None or not hasattr(active_view, "saveImage"):
                 view_type = type(active_view).__name__ if active_view is not None else "None"

--- a/src/freecad_mcp/operations/core.py
+++ b/src/freecad_mcp/operations/core.py
@@ -137,7 +137,14 @@ def get_view_operation(
     screenshot = freecad.get_active_screenshot(view_name, width, height, focus_object)
     if screenshot is not None:
         return [ImageContent(type="image", data=screenshot, mimeType="image/png")]
-    return text_response("Cannot get screenshot in the current view type (such as TechDraw or Spreadsheet)")
+    # The RPC returns None for several distinct failures; don't misdiagnose
+    # them all as a view-type problem.
+    return text_response(
+        "Could not capture a screenshot. Possible causes: no document is open, "
+        "the active view does not support screenshots (e.g. TechDraw or "
+        "Spreadsheet), or the capture itself failed. FreeCAD's Report View "
+        "logs the specific reason."
+    )
 
 
 def insert_part_from_library_operation(


### PR DESCRIPTION
`get_active_screenshot` returns `None` for three distinct failures — no active document, unsupported view type, and capture error — but the MCP client reported all of them as *"Cannot get screenshot in the current view type (such as TechDraw or Spreadsheet)"*. An LLM told that opens a 3D view it already has; the actual fix (open a document) never gets suggested.

- Addon: each failure path now logs its specific reason to the Report View, including the previously silent no-document case.
- Client: the message enumerates the possible causes and points at the Report View log.

The RPC wire contract (`str | None`) is unchanged, so mixed addon/client versions keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01715r6q45BLsEFsYyV1sYba