### PR TITLE
feat: add package.xml addon metadata

### DIFF
--- a/addon/FreeCADMCP/package.xml
+++ b/addon/FreeCADMCP/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+  <name>FreeCAD MCP</name>
+  <description>Control FreeCAD from AI assistants via the Model Context Protocol — XML-RPC server addon with GUI-thread dispatch, screenshots, parts library and FEM helpers.</description>
+  <version>0.1.19</version>
+  <date>2026-07-26</date>
+  <maintainer email="nekanat.stock@gmail.com">neka-nat</maintainer>
+  <license>MIT</license>
+  <url type="repository" branch="main">https://github.com/neka-nat/freecad-mcp</url>
+  <url type="bugtracker">https://github.com/neka-nat/freecad-mcp/issues</url>
+  <url type="readme">https://github.com/neka-nat/freecad-mcp/blob/main/README.md</url>
+  <content>
+    <workbench>
+      <classname>FreeCADMCPAddonWorkbench</classname>
+      <name>MCP Addon</name>
+    </workbench>
+  </content>
+</package>

--- a/addon/FreeCADMCP/package.xml
+++ b/addon/FreeCADMCP/package.xml
@@ -13,6 +13,11 @@
     <workbench>
       <classname>FreeCADMCPAddonWorkbench</classname>
       <name>MCP Addon</name>
+      <!-- InitGui.py lives at the package root. Without an explicit
+           subdirectory FreeCAD's package loader looks elsewhere and
+           silently loads NOTHING — no workbench, no auto-start, while
+           the rpc_server modules stay importable. -->
+      <subdirectory>./</subdirectory>
     </workbench>
   </content>
 </package>


### PR DESCRIPTION
The addon ships without any metadata file, so installed copies show no name/version/maintainer in the Addon Manager or the Mod scanner. That makes stale-deploy debugging ("which version is actually loaded?") harder than it needs to be — version now visible at a glance.

Standard [Package_Metadata](https://wiki.freecad.org/Package_Metadata) format 1, workbench classname matches `InitGui.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01715r6q45BLsEFsYyV1sYba