### PR TITLE
feat: add open_document tool for existing FCStd files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,11 @@
+# Changes
+
+## [Unreleased]
+
+### Added
+
+#### 2026-07-27 11:40:10 open_document tool を追加
+
+- 変更: 絶対パスの既存 `.FCStd` を開く MCP tool `open_document` を追加した。同じファイルが既に開いていれば再オープンせずアクティブ化する。
+- Why: `create_document`（新規）と `reload_document`（既開の再読込）の間に、ディスク上の既存ドキュメントを開く手段がなかったため。
+- Why not: 相対パス解決や STEP 等のインポート形式対応は、cwd 不定と document 操作の境界曖昧化を避けるため対象外とした。既開時の閉じ直しは `reload_document` の責務と重複するため採用しなかった。

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The `--host` value is validated on startup — it must be a valid IPv4/IPv6 addr
 ## Tools
 
 * `create_document`: Create a new document in FreeCAD.
+* `open_document`: Open an existing `.FCStd` document from an absolute path (activates an already-open copy instead of re-opening).
 * `create_object`: Create a new object in FreeCAD.
 * `edit_object`: Edit an object in FreeCAD.
 * `delete_object`: Delete an object in FreeCAD.

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -98,6 +98,15 @@ class FreeCADRPC:
             return {"success": True, "document_name": doc_name}
         return _err(res)
 
+    def open_document(self, file_path: str) -> dict[str, Any]:
+        """Open an existing .FCStd from an absolute path, or activate it
+        if the same file is already loaded.
+        """
+        res = dispatch_to_gui(lambda: self._open_document_gui(file_path))
+        if isinstance(res, dict) and res.get("success"):
+            return res
+        return _err(res)
+
     def run_fem_analysis(self, doc_name: str, analysis_name: str, timeout: int = 600) -> dict[str, Any]:
         """Run the CalculiX solver on an existing Fem::FemAnalysis and return summary results."""
         try:
@@ -316,6 +325,38 @@ class FreeCADRPC:
             f"Document '{doc_name}' reloaded from '{file_path}' via RPC.\n"
         )
         return True
+
+    def _open_document_gui(self, file_path: str):
+        if not isinstance(file_path, str) or not file_path:
+            return "file_path must be a non-empty string."
+        if not os.path.isabs(file_path):
+            return f"Path must be absolute: {file_path!r}."
+        if not file_path.lower().endswith(".fcstd"):
+            return f"Only .FCStd files are supported: {file_path!r}."
+        if not os.path.isfile(file_path):
+            return f"File not found: {file_path!r}."
+
+        target = os.path.realpath(file_path)
+        for name, doc in FreeCAD.listDocuments().items():
+            existing = getattr(doc, "FileName", None) or ""
+            if existing and os.path.realpath(existing) == target:
+                FreeCAD.setActiveDocument(name)
+                FreeCAD.Console.PrintMessage(
+                    f"Document '{name}' already open from '{file_path}'; activated via RPC.\n"
+                )
+                return {"success": True, "document_name": name}
+
+        try:
+            doc = FreeCAD.openDocument(file_path)
+        except Exception as e:
+            return str(e)
+        if doc is None:
+            return f"Failed to open document: {file_path!r}."
+        FreeCAD.setActiveDocument(doc.Name)
+        FreeCAD.Console.PrintMessage(
+            f"Document '{doc.Name}' opened from '{file_path}' via RPC.\n"
+        )
+        return {"success": True, "document_name": doc.Name}
 
     def _insert_part_from_library(self, relative_path):
         try:

--- a/issues/closed/done/20260727-open-document-tool.md
+++ b/issues/closed/done/20260727-open-document-tool.md
@@ -107,11 +107,11 @@ MCP tool `open_document` を追加し、絶対パスの既存 `.FCStd` を開け
 
 ## 受け入れ条件
 
-- [ ] 絶対パスの既存 `.FCStd` を `open_document` で開くと、そのドキュメントが `list_documents` に現れ、アクティブになる
-- [ ] 同じファイルが既に開いている場合、再オープンせず成功を返し、そのドキュメントがアクティブになる
-- [ ] 相対パス、`.FCStd` 以外、存在しないパスではエラーを返し、ドキュメント状態を壊さない
-- [ ] README の Tools 一覧に `open_document` が記載される
-- [ ] RPC → client → operation → MCP tool の配線が `reload_document` と同型である（静的読解）
+- [x] 絶対パスの既存 `.FCStd` を `open_document` で開くと、そのドキュメントが `list_documents` に現れ、アクティブになる
+- [x] 同じファイルが既に開いている場合、再オープンせず成功を返し、そのドキュメントがアクティブになる
+- [x] 相対パス、`.FCStd` 以外、存在しないパスではエラーを返し、ドキュメント状態を壊さない
+- [x] README の Tools 一覧に `open_document` が記載される
+- [x] RPC → client → operation → MCP tool の配線が `reload_document` と同型である（静的読解）
 
 ## Evidence
 
@@ -126,4 +126,7 @@ MCP tool `open_document` を追加し、絶対パスの既存 `.FCStd` を開け
 
 ## 完了記録
 
-- 未完了
+- 実装 commit: `dc0d5e8` — feat: 既存FCStdを開く open_document tool を追加する
+- 検証: 静的読解（配線・検証順序・既開枝・README grep）と `uv run` による import 確認。FreeCAD GUI 上の手動 RPC 確認は未実施（Issue 計画どおり主証拠は静的）
+- 品質gate: Standards/Spec レビューで Critical/High なし。Medium（実機未確認）は上記どおり受容
+- 状態: `issues/closed/done/` へ移動

--- a/issues/open/ready-for-agent/20260727-open-document-tool.md
+++ b/issues/open/ready-for-agent/20260727-open-document-tool.md
@@ -1,0 +1,129 @@
+---
+title: "open_document tool を追加する"
+---
+
+# open_document tool を追加する
+
+## 背景
+
+FreeCAD MCP には `create_document`（新規空ドキュメント）と `reload_document`（既に開いているドキュメントのディスク再読込）があるが、ディスク上の既存 `.FCStd` をパス指定で開く手段がない。addon 側では `reload_document` 内で `FreeCAD.openDocument(file_path)` を既に使っている。
+
+## 目的
+
+MCP tool `open_document` を追加し、絶対パスの既存 `.FCStd` を開け、そのドキュメントをアクティブにできるようにする。
+
+## 利用者意図・成果物・成功条件・制約
+
+- **意図:** 既存 FreeCAD ファイルを MCP から開けるようにする（`create` と `reload` のギャップを埋める）
+- **成果物:** `open_document` MCP tool（RPC / client / operation / server 配線と README）
+- **成功条件:** 絶対パスの `.FCStd` を開きアクティブ化できる。既開なら再オープンせず成功を返しアクティブ化する
+- **制約:** `.FCStd` のみ、絶対パスのみ
+
+## 範囲
+
+### 対象
+
+- `open_document` MCP tool の追加
+- 既に同じファイルが開いている場合は再オープンせず既存ドキュメントを使い、成功を返す
+- 開いた／再利用したドキュメントをアクティブにする
+- 相対パス・非 `.FCStd`・存在しないパスはエラーを返す
+- README Tools 一覧への追記
+
+### 対象外
+
+- STEP / IGES 等のインポート形式
+- `reload_document` の置き換えや仕様変更
+- 相対パス解決
+- CONTEXT.md / ADR 新規作成（既存「document」語彙の延長で足りる）
+- FreeCAD 統合の自動 E2E（リポジトリに FreeCAD 依存の test harness がない）
+
+## 確定した判断
+
+| 判断 | 採用 | 不採用と理由 |
+| --- | --- | --- |
+| 既開時 | 既存を使い成功＋アクティブ化 | エラー（使い勝手が悪い）／reload 相当（責務が `reload_document` と重複） |
+| アクティブ化 | する（`FreeCAD.setActiveDocument`） | しない（`get_view` 等との流れが悪い） |
+| 形式 | `.FCStd` のみ（拡張子は大小無視） | 任意形式（document 操作の境界が曖昧） |
+| パス | 絶対パスのみ | 相対（MCP の cwd が不定） |
+| 成功レスポンス形 | `{success, document_name}`（`create`/`reload` と同じ） | `already_open` フラグ追加（Interface を広げず、文言で区別可） |
+| 既開判定 | 開いている各 `doc.FileName` と入力パスを `os.path.realpath` で比較 | ドキュメント名だけで判定（ファイル実体とずれる） |
+
+## 変更する Module と Interface
+
+`reload_document` と同じ縦スライスを踏襲する。
+
+1. **Addon RPC**（`addon/FreeCADMCP/rpc_server/rpc_server.py`）
+   - Interface: `open_document(file_path: str) -> dict`
+   - 成功: `{"success": True, "document_name": <str>}`
+   - 失敗: `{"success": False, "error": <str>}`
+   - Implementation（GUI スレッド）:
+     1. 入力検証（絶対パス / `.FCStd` / ファイル存在）
+     2. 既開なら `setActiveDocument` してその名前を返す
+     3. 未開なら `FreeCAD.openDocument(file_path)`（通常アクティブ化される）。必要なら明示的に `setActiveDocument`
+     4. 開いたドキュメント名を返す
+2. **MCP client**（`src/freecad_mcp/freecad_client.py`）: `open_document(file_path) -> dict`
+3. **Operation**（`src/freecad_mcp/operations/core.py` + `__init__.py`）: `open_document_operation` — 成功／失敗を text response に整形
+4. **MCP tool**（`src/freecad_mcp/server.py`）: `@mcp.tool() open_document(ctx, file_path: str)`
+5. **README.md**: Tools 一覧に追記
+
+### error modes
+
+- 相対パス → error（ドキュメント状態は変更しない）
+- 拡張子が `.FCStd` でない → error
+- ファイルが存在しない → error
+- `openDocument` 失敗 → error 文字列を返す
+- 既開 → success（再オープンしない）
+
+### 互換性・security・rollback
+
+- 新規 tool のみ。既存 tool の Interface は変えない
+- 任意パスのオープンは `execute_code` と同程度のローカル権限前提。絶対パス強制で誤相対解決を避ける
+- 失敗時は新規ドキュメントを残さない（既開再利用時は閉じない）
+- 問題があれば tool 追加分を revert すれば足りる
+
+## Plan
+
+1. Addon に `open_document` / `_open_document_gui` を追加する
+2. client・operation・server を配線する
+3. README を更新する
+4. 受け入れ条件を静的読解と（可能な場合）手動 RPC 確認で検証する
+
+## 検証
+
+守る behavior: 「絶対パス `.FCStd` を開き／再利用し、アクティブな document として使える」
+
+守る seam: Addon RPC `open_document`（検証・既開判定・open・activate の Locality）
+
+| 受け入れ条件 | 手段 | 観察 |
+| --- | --- | --- |
+| 絶対パス `.FCStd` を開くと `list_documents` に現れアクティブ | 静的読解 + 手動（FreeCAD RPC 起動時） | RPC `open_document` → `list_documents`、ActiveDocument 名 |
+| 既開時は再オープンせず成功＋アクティブ | 静的読解（既開枝が `openDocument` を呼ばない）+ 手動 | 2 回呼び出しで document 数が増えない |
+| 相対／非 FCStd／不存在は error、状態を壊さない | 静的読解（検証が open より前）+ 手動 | error 戻り、`list_documents` 不変 |
+| README に記載 | grep | `open_document` が Tools 節にある |
+
+- 自動テスト: リポジトリに test suite / FreeCAD harness がないため新規 E2E は置かない
+- CI 観測: なし（現状 CI に FreeCAD なし）。review 時の静的確認を主証拠とする
+- fixture: 手動確認時のみ一時 `.FCStd` を用意（リポジトリへ commit しない）
+
+## 受け入れ条件
+
+- [ ] 絶対パスの既存 `.FCStd` を `open_document` で開くと、そのドキュメントが `list_documents` に現れ、アクティブになる
+- [ ] 同じファイルが既に開いている場合、再オープンせず成功を返し、そのドキュメントがアクティブになる
+- [ ] 相対パス、`.FCStd` 以外、存在しないパスではエラーを返し、ドキュメント状態を壊さない
+- [ ] README の Tools 一覧に `open_document` が記載される
+- [ ] RPC → client → operation → MCP tool の配線が `reload_document` と同型である（静的読解）
+
+## Evidence
+
+- `create_document` / `reload_document` / `list_documents` はあるが `open_document` はない（`src/freecad_mcp/server.py`）
+- `FreeCAD.openDocument(file_path)` は `_reload_document_gui` で使用済み（`addon/FreeCADMCP/rpc_server/rpc_server.py`）
+- 成功 dict 形は `{"success": True, "document_name": ...}` が既存パターン
+- リポジトリに `test_*.py` / pytest 設定なし（`pyproject.toml`）
+
+## 未決定事項
+
+- なし（実装可能な状態）
+
+## 完了記録
+
+- 未完了

--- a/src/freecad_mcp/freecad_client.py
+++ b/src/freecad_mcp/freecad_client.py
@@ -62,6 +62,9 @@ class FreeCADConnection:
     def reload_document(self, doc_name: str) -> dict[str, Any]:
         return self.server.reload_document(doc_name)
 
+    def open_document(self, file_path: str) -> dict[str, Any]:
+        return self.server.open_document(file_path)
+
     def insert_part_from_library(self, relative_path: str) -> dict[str, Any]:
         return self.server.insert_part_from_library(relative_path)
 

--- a/src/freecad_mcp/operations/__init__.py
+++ b/src/freecad_mcp/operations/__init__.py
@@ -11,6 +11,7 @@ from .core import (
     get_view_operation,
     insert_part_from_library_operation,
     list_documents_operation,
+    open_document_operation,
     reload_document_operation,
     run_fem_analysis_operation,
 )
@@ -28,6 +29,7 @@ __all__ = [
     "get_view_operation",
     "insert_part_from_library_operation",
     "list_documents_operation",
+    "open_document_operation",
     "reload_document_operation",
     "run_fem_analysis_operation",
 ]

--- a/src/freecad_mcp/operations/core.py
+++ b/src/freecad_mcp/operations/core.py
@@ -256,3 +256,22 @@ def reload_document_operation(
         logger.error(f"Failed to reload document: {str(e)}")
         return text_response(f"Failed to reload document: {str(e)}")
 
+
+def open_document_operation(
+    freecad: FreeCADConnection,
+    file_path: str,
+) -> ToolResponse:
+    """Open an existing .FCStd from an absolute path, or activate it if
+    already loaded.
+    """
+    try:
+        res = freecad.open_document(file_path)
+        if res.get("success"):
+            return text_response(
+                f"Document '{res['document_name']}' is open from '{file_path}'."
+            )
+        return text_response(f"Failed to open document: {res.get('error')}")
+    except Exception as e:
+        logger.error(f"Failed to open document: {str(e)}")
+        return text_response(f"Failed to open document: {str(e)}")
+

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -19,6 +19,7 @@ from .operations import (
     get_view_operation,
     insert_part_from_library_operation,
     list_documents_operation,
+    open_document_operation,
     reload_document_operation,
     run_fem_analysis_operation,
 )
@@ -445,6 +446,32 @@ def reload_document(ctx: Context, doc_name: str) -> list[TextContent]:
         ```
     """
     return reload_document_operation(get_freecad_connection(), doc_name)
+
+
+@mcp.tool()
+def open_document(ctx: Context, file_path: str) -> list[TextContent]:
+    """Open an existing FreeCAD document from an absolute .FCStd path.
+
+    If the same file is already open, the existing document is reused
+    and activated (it is not closed and re-opened). Use
+    ``reload_document`` when you need to pick up on-disk changes.
+
+    Args:
+        file_path: Absolute path to a ``.FCStd`` file. Relative paths
+            and non-``.FCStd`` files are rejected.
+
+    Returns:
+        A message confirming the document was opened (or already open
+        and activated), or describing the failure.
+
+    Examples:
+        ```json
+        {
+            "file_path": "/Users/me/models/chassis.FCStd"
+        }
+        ```
+    """
+    return open_document_operation(get_freecad_connection(), file_path)
 
 
 @mcp.tool()

--- a/uv.lock
+++ b/uv.lock
@@ -66,7 +66,7 @@ wheels = [
 
 [[package]]
 name = "freecad-mcp"
-version = "0.1.17"
+version = "0.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- Add MCP tool `open_document` to open an existing `.FCStd` from an absolute path (reuse + activate if already open).
- Wire addon RPC → client → operation → server, and document it in README / CHANGES.
- Close issue `issues/closed/done/20260727-open-document-tool.md`.

## Test plan
- [ ] Reinstall addon (`cp -r addon/FreeCADMCP …/Mod/`) and restart FreeCAD; Start RPC Server
- [ ] RPC smoke: `ping`, `open_document(/abs/path.FCStd)`, confirm it appears in `list_documents` and is active
- [ ] Call `open_document` again on the same path; document count must not increase
- [ ] Relative path / non-`.FCStd` / missing file return errors without changing open docs
- [ ] Optional: Claude Desktop / MCP client config pointing at this branch, call `open_document`


Made with [Cursor](https://cursor.com)