### PR TITLE
fix(rpc): expose App/Gui to execute_code, and bound the mouse guard

### DIFF
--- a/addon/FreeCADMCP/rpc_server/gui_dispatch.py
+++ b/addon/FreeCADMCP/rpc_server/gui_dispatch.py
@@ -38,6 +38,53 @@ _SHUTDOWN = object()
 _processing = False  # re-entrancy guard: True while process_gui_tasks is draining
 _processing_since: float = 0.0  # wall-clock time when _processing became True
 
+# Qt can miss a mouse-release when the button is released outside the FreeCAD
+# window (drag out of the viewport, release there). QApplication.mouseButtons()
+# then reports the button as held indefinitely. An unbounded mouse guard turns
+# that into a permanently wedged RPC server: every tick defers, no task ever
+# runs, and every call fails with an unexplained timeout. Cap how long we are
+# willing to believe a drag is still in progress.
+MOUSE_DEFER_MAX_S = 5.0
+# None = unarmed. Do not use 0.0 as the sentinel: time.monotonic() may legitimately
+# return 0.0, which would re-arm the timer every tick and never reach the cap.
+_mouse_defer_since: "float | None" = None
+_stale_mouse_warned = False
+
+# Why the last tick declined to process, recorded on the GUI thread so the
+# RPC thread can report it on timeout without touching Qt off-thread.
+_last_defer_reason: str = ""
+
+
+def _mouse_guard_should_defer(mouse_down: bool, now: float) -> bool:
+    """Whether to skip this tick because mouse buttons are held.
+
+    Defers while a genuine 3D-navigation drag is plausibly in progress, but
+    gives up after ``MOUSE_DEFER_MAX_S``: buttons reported held that long
+    across an MCP call are far more likely stale Qt state than a real drag,
+    and deferring forever is strictly worse than interrupting a drag.
+    """
+    global _mouse_defer_since, _stale_mouse_warned
+    if not mouse_down:
+        _mouse_defer_since = None
+        _stale_mouse_warned = False
+        return False
+    if _mouse_defer_since is None:
+        _mouse_defer_since = now
+        return True
+    return (now - _mouse_defer_since) < MOUSE_DEFER_MAX_S
+
+
+def _warn_stale_mouse_once() -> None:
+    """Announce the override once per stuck-button episode."""
+    global _stale_mouse_warned
+    if _stale_mouse_warned:
+        return
+    _stale_mouse_warned = True
+    FreeCAD.Console.PrintWarning(
+        f"MCP RPC: mouse buttons reported held for over {MOUSE_DEFER_MAX_S:.0f}s. "
+        "Treating as stale Qt input state and processing queued tasks anyway.\n"
+    )
+
 
 class _WakeSignal(QtCore.QObject):
     """Qt signal bridge for cross-thread GUI-task wakeup.
@@ -103,7 +150,7 @@ def process_gui_tasks(reschedule: bool = True) -> None:
     ``reschedule=False`` is used by the immediate-wake path so it does not
     start a second heartbeat chain alongside the existing 500 ms one.
     """
-    global _processing, _processing_since
+    global _processing, _processing_since, _last_defer_reason
     if _processing:
         return  # re-entrant call from processEvents inside a task; skip
 
@@ -111,13 +158,21 @@ def process_gui_tasks(reschedule: bool = True) -> None:
     try:
         if _rpc_request_queue.empty():
             return  # nothing queued; skip cursor/status-bar churn on idle heartbeat ticks
-        if QtWidgets.QApplication.mouseButtons() != QtCore.Qt.NoButton:
+
+        mouse_down = QtWidgets.QApplication.mouseButtons() != QtCore.Qt.NoButton
+        if _mouse_guard_should_defer(mouse_down, time.monotonic()):
+            _last_defer_reason = "mouse buttons held (3D navigation drag)"
             return  # user is dragging; defer to next tick
+        if mouse_down:
+            _warn_stale_mouse_once()  # stale state: fall through and process anyway
         if QtWidgets.QApplication.activePopupWidget() is not None:
+            _last_defer_reason = "a popup or context menu is open in FreeCAD"
             return  # context menu or popup open; defer to next tick
         if QtWidgets.QApplication.activeModalWidget() is not None:
+            _last_defer_reason = "a modal dialog is open in FreeCAD"
             return  # modal dialog open; defer to next tick
 
+        _last_defer_reason = ""
         _processing = True
         _processing_since = time.monotonic()
         app = QtWidgets.QApplication.instance()
@@ -205,6 +260,13 @@ def dispatch_to_gui(task: Callable[[], Any], timeout: float = 60) -> Any:
             hint = (
                 f" (GUI thread has been busy for {busy_for:.1f}s — "
                 "consider execute_code_async for heavy OCCT operations)"
+            )
+        elif _last_defer_reason:
+            # Never silently time out on a guard: name it so the next wedge
+            # diagnoses itself instead of looking like a dead server.
+            hint = (
+                f" (GUI thread is not processing tasks: {_last_defer_reason}; "
+                f"{_rpc_request_queue.qsize()} task(s) queued)"
             )
         else:
             hint = ""

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -1,6 +1,13 @@
 import FreeCAD
 import FreeCADGui
 
+# Aliases matching FreeCAD's macro/console environment. execute_code and
+# execute_code_async exec user code against this module's globals, so without
+# these the ubiquitous `App.getDocument(...)` / `Gui.activeDocument()` idiom
+# used throughout FreeCAD's docs and macros fails with NameError.
+App = FreeCAD
+Gui = FreeCADGui
+
 import contextlib
 import base64
 import io


### PR DESCRIPTION
Two independent robustness fixes to the RPC server, both found while driving FreeCAD 1.1.2 through the MCP server over a long modelling session.

## 1. `App` / `Gui` are undefined inside `execute_code` (6f984c7)

`execute_code` and `execute_code_async` exec user-submitted code against `rpc_server`'s module globals. Those import `FreeCAD` and `FreeCADGui` but define no short aliases, so the `App.getDocument(...)` / `Gui.activeDocument()` idiom used throughout FreeCAD's documentation and macros fails with `NameError`.

That idiom dominates FreeCAD example code, so it is the first thing an LLM client reaches for — in practice this fires constantly.

Binds `App = FreeCAD` and `Gui = FreeCADGui` at module level. These are aliases, not copies: `App is FreeCAD` and `Gui is FreeCADGui` both hold, and the existing `FreeCAD` / `FreeCADGui` names are unchanged. `Part` is deliberately left alone — `import Part` inside a snippet works, and aliasing it would mean importing a heavy module at addon load for every user.

## 2. A lost mouse-release wedges the server permanently (ec484f2)

`process_gui_tasks` skips the current tick whenever `QApplication.mouseButtons()` reports a button held, so MCP tasks cannot interrupt 3D navigation drags. The guard was unbounded, which assumes Qt's mouse state is always accurate.

It isn't. Releasing a button outside the FreeCAD window (drag out of the viewport, release there) loses the release event, and `mouseButtons()` then reports the button held indefinitely. Every tick defers, the queue never drains, and the RPC server is wedged: `ping` and `list_documents` still answer while every GUI-bound call fails after 60s with no explanation. Recovery requires clicking in the viewport or restarting FreeCAD.

Observed twice in one session before the cause was found.

Caps the deferral at `MOUSE_DEFER_MAX_S` (5s). Buttons reported held that long across an MCP call are far more likely stale Qt state than a live drag, and interrupting a real drag is strictly better than wedging until restart. The override logs a warning once per episode and re-arms on release.

Also records why a tick declined to process and surfaces it in the dispatch timeout message, so this class of failure names its own cause:

```
before:  GUI dispatch timed out after 60s
after:   GUI dispatch timed out after 60s (GUI thread is not processing tasks:
         mouse buttons held (3D navigation drag); 6 task(s) queued)
```

The unarmed sentinel is `None` rather than `0.0`: `time.monotonic()` may legitimately return `0.0`, which would re-arm the timer on every tick and never reach the cap.

## Verification

Both fixes ran against a live FreeCAD 1.1.2 session for several hours.

**App/Gui** — namespace probe confirms `App`, `Gui`, `FreeCAD`, `FreeCADGui` all resolve, and that `App is FreeCAD` / `Gui is FreeCADGui`. A `Part::Cut` built entirely through the `App` idiom solves to its analytic volume.

**Mouse guard** — 23 unit tests over the guard logic: genuine drags respected up to the cap, stuck state clears, release re-arms, the warning fires exactly once per episode, and a replay of the observed wedge (400 ticks with the button stuck) recovers. The first version of the patch used `0.0` as the sentinel and the tests caught it.

The improved timeout message then earned its keep independently, reporting `GUI thread has been busy for 9880.4s` when a long-running OCCT operation blocked the queue — previously that would have been an unexplained timeout.

## Notes for reviewers

- `MOUSE_DEFER_MAX_S = 5.0` is a judgement call. The tradeoff is deliberately asymmetric: interrupting a long drag is a cosmetic annoyance, wedging until restart is not. Happy to change the value or make it configurable.
- The two commits are independent and can be taken separately.