### PR TITLE
Support Python-implemented object types in create_object (Part::Tube, Draft::*)

### DIFF
--- a/addon/FreeCADMCP/rpc_server/object_factory.py
+++ b/addon/FreeCADMCP/rpc_server/object_factory.py
@@ -6,6 +6,8 @@ legacy parameter remapping, generic FEM-typed objects, and arbitrary
 public entry point that selects the branch.
 """
 
+from contextlib import contextmanager
+
 import FreeCAD
 import ObjectsFem
 
@@ -77,16 +79,136 @@ def _create_fem_object(doc: FreeCAD.Document, obj: Object):
     return res
 
 
-#: Python-implemented features that look like ordinary types but are absent
-#: from FreeCAD's C++ type registry, mapped to the factory that does build
-#: them. ``doc.addObject`` rejects every key here.
+@contextmanager
+def _active_document(doc: FreeCAD.Document):
+    """Make ``doc`` the active document for the duration of the block.
+
+    The Draft factories create into ``FreeCAD.ActiveDocument`` rather than a
+    document passed in, so without this an RPC call naming one document can
+    drop geometry into whichever one the GUI happens to have focused.
+    """
+    previous = FreeCAD.ActiveDocument
+    FreeCAD.setActiveDocument(doc.Name)
+    try:
+        yield
+    finally:
+        if previous is not None:
+            try:
+                FreeCAD.setActiveDocument(previous.Name)
+            except Exception:
+                pass
+
+
+def _require(properties: dict, key: str, obj_type: str):
+    """Pop a property the factory needs as a constructor argument.
+
+    Popping keeps it out of the later ``set_object_property`` pass, which would
+    otherwise try to re-assign the raw JSON value.
+    """
+    if key not in properties:
+        raise ValueError(
+            f"'{obj_type}' requires a '{key}' property, which was not supplied."
+        )
+    return properties.pop(key)
+
+
+def _to_vectors(raw, obj_type: str) -> list:
+    """Convert a JSON point list to FreeCAD.Vector, accepting dicts or sequences."""
+    if not isinstance(raw, (list, tuple)) or not raw:
+        raise ValueError(f"'{obj_type}' needs 'Points' to be a non-empty list.")
+    points = []
+    for entry in raw:
+        if isinstance(entry, dict):
+            points.append(
+                FreeCAD.Vector(entry.get("x", 0), entry.get("y", 0), entry.get("z", 0))
+            )
+        elif isinstance(entry, (list, tuple)) and len(entry) in (2, 3):
+            x, y, z = (list(entry) + [0])[:3]
+            points.append(FreeCAD.Vector(x, y, z))
+        else:
+            raise ValueError(
+                f"Invalid point {entry!r} for '{obj_type}'; expected "
+                "{'x': .., 'y': .., 'z': ..} or [x, y, z]."
+            )
+    return points
+
+
+def _make_tube(doc, name, properties):
+    from BasicShapes import Shapes
+
+    return Shapes.addTube(doc, name)
+
+
+def _make_draft_circle(doc, name, properties):
+    import Draft
+
+    return Draft.make_circle(_require(properties, "Radius", "Draft::Circle"))
+
+
+def _make_draft_rectangle(doc, name, properties):
+    import Draft
+
+    return Draft.make_rectangle(
+        _require(properties, "Length", "Draft::Rectangle"),
+        _require(properties, "Height", "Draft::Rectangle"),
+    )
+
+
+def _make_draft_polygon(doc, name, properties):
+    import Draft
+
+    return Draft.make_polygon(
+        _require(properties, "FacesNumber", "Draft::Polygon"),
+        _require(properties, "Radius", "Draft::Polygon"),
+    )
+
+
+def _make_draft_wire(doc, name, properties):
+    import Draft
+
+    points = _to_vectors(_require(properties, "Points", "Draft::Wire"), "Draft::Wire")
+    return Draft.make_wire(points, closed=bool(properties.pop("Closed", False)))
+
+
+#: Types implemented in Python rather than C++, so absent from FreeCAD's type
+#: registry and rejected by ``doc.addObject``. Each entry adapts the real
+#: factory to a uniform ``(doc, name, properties) -> DocumentObject`` call.
+#: The signatures genuinely differ -- addTube takes the document and name,
+#: the Draft factories take geometry and neither -- so this cannot collapse
+#: into a (module, function) lookup the way the Fem:: branch does.
+_PYTHON_FACTORIES = {
+    "Part::Tube": _make_tube,
+    "Draft::Circle": _make_draft_circle,
+    "Draft::Rectangle": _make_draft_rectangle,
+    "Draft::Polygon": _make_draft_polygon,
+    "Draft::Wire": _make_draft_wire,
+}
+
+
+def _create_python_object(doc: FreeCAD.Document, obj: Object):
+    """Create a Python-implemented feature via its factory."""
+    with _active_document(doc):
+        res = _PYTHON_FACTORIES[obj.type](doc, obj.name, obj.properties)
+    if res is None:
+        raise ValueError(f"The factory for '{obj.type}' returned no object.")
+    # Only addTube honours a requested name; the Draft factories name objects
+    # themselves (make_wire even yields "Line"), so carry the caller's name on
+    # the Label and let the real Name go back in the response.
+    res.Label = obj.name
+    set_object_property(doc, res, obj.properties)
+    FreeCAD.Console.PrintMessage(
+        f"{obj.type} '{res.Name}' created in '{doc.Name}' via RPC.\n"
+    )
+    return res
+
+
+#: Python-implemented features with no factory here yet. Keys must stay
+#: disjoint from _PYTHON_FACTORIES, which handles its own types before
+#: _create_generic_object is ever reached.
 _UNREGISTERED_TYPE_HINTS = {
-    "Part::Tube": "BasicShapes.Shapes.addTube(doc, name)",
-    "Draft::Circle": "Draft.make_circle(radius)",
-    "Draft::Rectangle": "Draft.make_rectangle(length, height)",
-    "Draft::Polygon": "Draft.make_polygon(nfaces, radius)",
-    "Draft::Wire": "Draft.make_wire(points, closed=False)",
     "Draft::Point": "Draft.make_point(x, y, z)",
+    "Draft::Ellipse": "Draft.make_ellipse(majradius, minradius)",
+    "Draft::BSpline": "Draft.make_bspline(points, closed=False)",
 }
 
 
@@ -149,6 +271,8 @@ def create_object_gui(doc_name: str, obj: Object):
             created = _create_fem_mesh(doc, obj)
         elif obj.type.startswith("Fem::"):
             created = _create_fem_object(doc, obj)
+        elif obj.type in _PYTHON_FACTORIES:
+            created = _create_python_object(doc, obj)
         else:
             created = _create_generic_object(doc, obj)
 

--- a/addon/FreeCADMCP/rpc_server/object_factory.py
+++ b/addon/FreeCADMCP/rpc_server/object_factory.py
@@ -77,8 +77,48 @@ def _create_fem_object(doc: FreeCAD.Document, obj: Object):
     return res
 
 
+#: Python-implemented features that look like ordinary types but are absent
+#: from FreeCAD's C++ type registry, mapped to the factory that does build
+#: them. ``doc.addObject`` rejects every key here.
+_UNREGISTERED_TYPE_HINTS = {
+    "Part::Tube": "BasicShapes.Shapes.addTube(doc, name)",
+    "Draft::Circle": "Draft.make_circle(radius)",
+    "Draft::Rectangle": "Draft.make_rectangle(length, height)",
+    "Draft::Polygon": "Draft.make_polygon(nfaces, radius)",
+    "Draft::Wire": "Draft.make_wire(points, closed=False)",
+    "Draft::Point": "Draft.make_point(x, y, z)",
+}
+
+
+def _unregistered_type_message(obj_type: str) -> str:
+    """Explain an ``addObject`` type-registry miss in terms the caller can act on.
+
+    FreeCAD's own error ("is not a document object type") gives no hint that
+    the type may be perfectly real but Python-implemented, which sends callers
+    hunting for a typo that isn't there.
+    """
+    hint = _UNREGISTERED_TYPE_HINTS.get(obj_type)
+    if hint is None and obj_type.startswith("Draft::"):
+        hint = "the matching Draft.make_* factory"
+    suggestion = (
+        f" It is implemented in Python rather than C++, so build it with "
+        f"execute_code instead, e.g. {hint}."
+        if hint
+        else " Check the spelling, or build it with execute_code."
+    )
+    return (
+        f"'{obj_type}' is not a type registered with FreeCAD, so create_object "
+        f"cannot make it.{suggestion}"
+    )
+
+
 def _create_generic_object(doc: FreeCAD.Document, obj: Object):
-    res = doc.addObject(obj.type, obj.name)
+    try:
+        res = doc.addObject(obj.type, obj.name)
+    except Exception as e:
+        if "not a document object type" in str(e):
+            raise ValueError(_unregistered_type_message(obj.type)) from e
+        raise
     set_object_property(doc, res, obj.properties)
     FreeCAD.Console.PrintMessage(
         f"{res.TypeId} '{res.Name}' added to '{doc.Name}' via RPC.\n"

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -116,11 +116,24 @@ def create_object(
     """Create a new object in FreeCAD.
 
     ``obj_type`` must name a type registered in FreeCAD's C++ type system, such
-    as "Part::", "PartDesign::" or "Fem::" types. Note that a number of FreeCAD
-    features are implemented in Python rather than C++ (the whole Draft
-    workbench, and Part::Tube among the Part primitives). Those are not
-    registered types, so this tool cannot create them -- build them with
-    ``execute_code`` instead.
+    as "Part::", "PartDesign::" or "Fem::" types. A number of FreeCAD features
+    are implemented in Python rather than C++ and so are not registered types;
+    of those, these are supported here through dedicated factories, and each
+    requires the properties listed beside it:
+
+        Part::Tube        InnerRadius, OuterRadius, Height
+        Draft::Circle     Radius
+        Draft::Rectangle  Length, Height
+        Draft::Polygon    FacesNumber, Radius
+        Draft::Wire       Points (list of {x, y, z}), optional Closed
+
+    Any other Python-implemented type (Draft::Point, Draft::Ellipse, ...) must
+    be built with ``execute_code`` instead.
+
+    Note that the Draft factories name objects themselves, so for those the
+    returned object_name will differ from the requested obj_name, which is
+    applied to the object's Label instead. Always use the returned name in
+    later get_object/edit_object calls.
 
     Args:
         doc_name: The name of the document to create the object in.
@@ -173,6 +186,21 @@ def create_object(
             "obj_properties": {
                 "Base": "Box",
                 "Tool": "Cylinder"
+            }
+        }
+        ```
+
+        If you want to create a pipe with an outer diameter of 250, a 10 wall
+        and a length of 500, you can use the following data.
+        ```json
+        {
+            "doc_name": "MyPipe",
+            "obj_name": "Pipe",
+            "obj_type": "Part::Tube",
+            "obj_properties": {
+                "OuterRadius": 125,
+                "InnerRadius": 115,
+                "Height": 500
             }
         }
         ```

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -114,11 +114,17 @@ def create_object(
     obj_properties: dict[str, Any] = None,
 ) -> list[TextContent | ImageContent]:
     """Create a new object in FreeCAD.
-    Object type is starts with "Part::" or "Draft::" or "PartDesign::" or "Fem::".
+
+    ``obj_type`` must name a type registered in FreeCAD's C++ type system, such
+    as "Part::", "PartDesign::" or "Fem::" types. Note that a number of FreeCAD
+    features are implemented in Python rather than C++ (the whole Draft
+    workbench, and Part::Tube among the Part primitives). Those are not
+    registered types, so this tool cannot create them -- build them with
+    ``execute_code`` instead.
 
     Args:
         doc_name: The name of the document to create the object in.
-        obj_type: The type of the object to create (e.g. 'Part::Box', 'Part::Cylinder', 'Draft::Circle', 'PartDesign::Body', etc.).
+        obj_type: The type of the object to create (e.g. 'Part::Box', 'Part::Cylinder', 'Part::Cut', 'PartDesign::Body', etc.).
         obj_name: The name of the object to create.
         obj_properties: The properties of the object to create.
 
@@ -157,12 +163,17 @@ def create_object(
         }
         ```
 
-        If you want to create a circle with a radius of 10, you can use the following data.
+        If you want to cut one solid out of another, create both solids first,
+        then reference them by name as 'Base' and 'Tool'.
         ```json
         {
-            "doc_name": "MyCircle",
-            "obj_name": "Circle",
-            "obj_type": "Draft::Circle",
+            "doc_name": "MyPart",
+            "obj_name": "Cut",
+            "obj_type": "Part::Cut",
+            "obj_properties": {
+                "Base": "Box",
+                "Tool": "Cylinder"
+            }
         }
         ```
 


### PR DESCRIPTION
## Problem

`create_object` cannot create any FreeCAD feature that is implemented in Python rather than C++.

`doc.addObject(type, name)` resolves its first argument against FreeCAD's **C++ type registry** (185 entries on FreeCAD 1.1.3). Features implemented in Python never enter that registry, so their conventional type names exist only in documentation:

| Type | `addObject` |
|---|---|
| `Part::Box`, `Part::Cylinder`, `Part::Cut` | works |
| `Part::Tube` | `is not a document object type` |
| `Draft::Circle`, `Draft::Wire`, `Draft::Polygon` | `is not a document object type` |

This also means the tool description was advertising a call that can never succeed: `Draft::Circle` was named in the `obj_type` docs and given a complete worked JSON example. Since that text *is* the tool schema, every model using this MCP was being told to make a failing call.

## Changes

Three separate commits, one per issue:

**1. `docs:` stop advertising object types `create_object` cannot make**

State the actual constraint (registered C++ types), name the Python-implemented exceptions, and replace the broken `Draft::Circle` example with a `Part::Cut` one — which also documents the `Base`/`Tool` reference handling already present in `set_object_property`.

**2. `feat(addon):` explain type-registry misses instead of leaking FreeCAD's error**

FreeCAD's `"'X' is not a document object type"` gives no hint that the type may be entirely real but Python-implemented, so callers hunt for a typo that isn't there. `_create_generic_object` now catches that specific failure and re-raises a message naming the cause and the factory that does build the object. Unrelated `addObject` failures propagate untouched.

**3. `feat(addon):` create Python-implemented types via a factory registry**

The `Fem::` branch already solves this shape of problem by routing to `ObjectsFem` factories instead of `addObject`. This extends the same dispatch to `Part::Tube`, `Draft::Circle`, `Draft::Rectangle`, `Draft::Polygon` and `Draft::Wire`. Anything else Python-implemented still falls through to the improved error from commit 2.

Two details that the `Fem::` branch does not have to handle:

- **The factory signatures are incompatible.** `Shapes.addTube` takes `(doc, name)`; the Draft factories take geometry and take neither. So entries are adapter callables rather than a `(module, function)` lookup — reflection over a naming convention, as in `_create_fem_object`, does not generalize here, because `ObjectsFem`'s uniform `makeXxx(doc, name)` convention is unusual.
- **The Draft factories create into `FreeCAD.ActiveDocument`**, not a document argument. Left alone, an RPC call naming one document would drop geometry into whichever document the GUI last focused. `_active_document()` pins and restores it.

Constructor arguments are popped from `properties` so the later `set_object_property` pass does not re-assign raw JSON — this matters for `Draft::Wire`, whose `Points` need converting to `FreeCAD.Vector` first. Draft names its own objects (`make_wire` yields `Line`), so the requested name goes on `Label` and the response carries the real `Name`, consistent with the existing contract.

## Verification

Tested against FreeCAD 1.1.3 by driving `create_object_gui` directly:

- All five Python-backed types create in the **correct** document while a decoy document is left active, and the decoy stays empty — this is the test that actually exercises the `ActiveDocument` guard; a single-document test passes with the bug fully present.
- `Part::Tube` with `OuterRadius: 125, InnerRadius: 115, Height: 500` produces a valid single solid of volume `3769911.2` mm³, matching `pi*(125^2-115^2)*500` exactly.
- `Part::Box` and the FEM paths are unaffected.
- A missing required property reports which one is missing.
- `_PYTHON_FACTORIES` and `_UNREGISTERED_TYPE_HINTS` are disjoint, so no type is both supported and given a workaround hint.

No new dependencies. `BasicShapes` and `Draft` ship with FreeCAD core and are imported lazily inside the adapters, so a missing workbench cannot break addon load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
