### PR TITLE
Add macro authoring and execution tools (list/get/create/edit/run)

### DIFF
--- a/addon/FreeCADMCP/rpc_server/macros.py
+++ b/addon/FreeCADMCP/rpc_server/macros.py
@@ -1,0 +1,237 @@
+"""Macro authoring and execution for the RPC server.
+
+FreeCAD macros are ordinary ``.FCMacro`` files (plain Python) living in the
+user macro directory, so authoring them is file I/O and needs no GUI thread.
+Execution is the awkward part and is deliberately kept separate --- see
+``run_macro`` for why it cannot simply be run and awaited.
+"""
+
+import os
+import re
+
+import FreeCAD
+import FreeCADGui
+from PySide import QtCore
+
+from rpc_server.gui_dispatch import dispatch_to_gui
+
+
+MACRO_SUFFIX = ".FCMacro"
+
+#: A macro name must be a plain file name. These helpers write files that
+#: run_macro will later execute as Python, so a name escaping the macro
+#: directory ("../../.bashrc") has to be impossible rather than unlikely.
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._-]*$")
+
+_DOCSTRING = re.compile(r'"""(.*?)"""|\'\'\'(.*?)\'\'\'', re.S)
+
+
+def macro_dir() -> str:
+    """The user macro directory FreeCAD itself lists macros from.
+
+    Read from FreeCAD rather than configured here, so this works for any
+    user. Note it is whatever the user pointed FreeCAD at, which may be a
+    cloud-synced folder.
+    """
+    return FreeCAD.getUserMacroDir(True)
+
+
+def _resolve(name: str) -> str:
+    """Map a macro name to an absolute path inside the macro directory."""
+    if not isinstance(name, str) or not _SAFE_NAME.match(name.strip()):
+        raise ValueError(
+            f"Invalid macro name {name!r}. Use letters, digits, spaces, "
+            "'.', '_' or '-', starting with a letter or digit."
+        )
+    name = name.strip()
+    if not name.endswith(MACRO_SUFFIX):
+        name += MACRO_SUFFIX
+
+    directory = os.path.realpath(macro_dir())
+    path = os.path.realpath(os.path.join(directory, name))
+    # Belt and braces: the regex already forbids separators, but resolve and
+    # re-check so a symlink inside the macro dir cannot redirect a write out.
+    if os.path.dirname(path) != directory:
+        raise ValueError(f"Macro name {name!r} resolves outside the macro directory.")
+    return path
+
+
+def _summary(source: str) -> str:
+    """First meaningful line of a macro's docstring, for listings."""
+    match = _DOCSTRING.search(source[:4096])
+    block = (match.group(1) or match.group(2)) if match else ""
+    for line in block.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    for line in source[:4096].splitlines():
+        line = line.strip()
+        if line.startswith("#") and not line.startswith("#!") and "coding" not in line:
+            return line.lstrip("# ").strip()
+    return ""
+
+
+def list_macros() -> dict:
+    """Every macro in the macro directory, with size and summary line."""
+    directory = macro_dir()
+    if not os.path.isdir(directory):
+        return {"success": True, "macro_dir": directory, "macros": []}
+
+    macros = []
+    for entry in sorted(os.listdir(directory)):
+        if not entry.endswith(MACRO_SUFFIX):
+            continue
+        path = os.path.join(directory, entry)
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                head = fh.read(4096)
+            size = os.path.getsize(path)
+        except OSError as e:
+            macros.append({"name": entry, "error": str(e)})
+            continue
+        macros.append(
+            {
+                "name": entry[: -len(MACRO_SUFFIX)],
+                "file": entry,
+                "bytes": size,
+                "summary": _summary(head),
+            }
+        )
+    return {"success": True, "macro_dir": directory, "macros": macros}
+
+
+def get_macro(name: str) -> dict:
+    """Full source of one macro."""
+    path = _resolve(name)
+    if not os.path.isfile(path):
+        raise ValueError(f"Macro '{name}' not found in {macro_dir()}.")
+    with open(path, encoding="utf-8") as fh:
+        code = fh.read()
+    return {"success": True, "name": os.path.basename(path), "path": path, "code": code}
+
+
+def create_macro(name: str, code: str, overwrite: bool = False) -> dict:
+    """Write a new macro file."""
+    if not isinstance(code, str) or not code.strip():
+        raise ValueError("Macro code must be a non-empty string.")
+    path = _resolve(name)
+    if os.path.exists(path) and not overwrite:
+        raise ValueError(
+            f"Macro '{os.path.basename(path)}' already exists. "
+            "Pass overwrite=True to replace it, or use edit_macro to change part of it."
+        )
+    directory = os.path.dirname(path)
+    os.makedirs(directory, exist_ok=True)
+    if not code.endswith("\n"):
+        code += "\n"
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(code)
+    FreeCAD.Console.PrintMessage(f"MCP: wrote macro {path}\n")
+    return {
+        "success": True,
+        "name": os.path.basename(path),
+        "path": path,
+        "bytes": len(code.encode("utf-8")),
+    }
+
+
+def edit_macro(name: str, old_string: str, new_string: str, replace_all: bool = False) -> dict:
+    """Replace an exact substring inside an existing macro.
+
+    String replacement rather than whole-file rewrite: these files reach
+    100 kB, and round-tripping one through a model to change a single value
+    invites it to silently drop the parts it only half-remembers. A
+    non-matching edit fails loudly instead of corrupting the macro.
+    """
+    if not isinstance(old_string, str) or old_string == "":
+        raise ValueError("old_string must be a non-empty string.")
+    if old_string == new_string:
+        raise ValueError("old_string and new_string are identical; nothing to do.")
+
+    path = _resolve(name)
+    if not os.path.isfile(path):
+        raise ValueError(f"Macro '{name}' not found in {macro_dir()}.")
+    with open(path, encoding="utf-8") as fh:
+        source = fh.read()
+
+    count = source.count(old_string)
+    if count == 0:
+        raise ValueError(f"old_string not found in macro '{os.path.basename(path)}'.")
+    if count > 1 and not replace_all:
+        raise ValueError(
+            f"old_string appears {count} times in '{os.path.basename(path)}'. "
+            "Include surrounding lines to make it unique, or pass replace_all=True."
+        )
+
+    updated = source.replace(old_string, new_string)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(updated)
+    FreeCAD.Console.PrintMessage(f"MCP: edited macro {path} ({count} replacement(s))\n")
+    return {
+        "success": True,
+        "name": os.path.basename(path),
+        "path": path,
+        "replacements": count,
+    }
+
+
+def _execute(path: str) -> None:
+    """Run a macro file the way FreeCAD's own macro runner does.
+
+    ``__name__`` must be ``"__main__"``: the common macro idiom guards its
+    entry point with ``if __name__ == '__main__'``, and without this the
+    macro would load and do nothing at all.
+    """
+    try:
+        with open(path, encoding="utf-8") as fh:
+            source = fh.read()
+        namespace = {"__name__": "__main__", "__file__": path, "__builtins__": __builtins__}
+        exec(compile(source, path, "exec"), namespace)
+    except Exception as e:
+        import traceback
+
+        FreeCAD.Console.PrintError(
+            f"MCP: macro '{os.path.basename(path)}' raised "
+            f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
+        )
+
+
+def run_macro(name: str) -> dict:
+    """Start a macro on the GUI thread and return without waiting for it.
+
+    Detached on purpose, for a reason specific to this server. Macros
+    routinely open a modal Qt dialog, and ``process_gui_tasks`` skips every
+    tick while ``activeModalWidget()`` is set --- so awaiting a macro would
+    stall the entire MCP dispatch loop until a human dismissed the dialog.
+    Running it in a background thread instead is not an option either, since
+    Qt widgets may only be constructed on the GUI thread.
+
+    So: hop to the GUI thread (fast, returns at once) purely to arm a
+    zero-delay timer. The macro then runs from the event loop after the
+    dispatch task has finished, on the right thread, blocking nothing.
+
+    The corollary is that this cannot report what the macro did. Anything
+    the macro creates has to be observed afterwards with get_objects.
+    """
+    path = _resolve(name)
+    if not os.path.isfile(path):
+        raise ValueError(f"Macro '{name}' not found in {macro_dir()}.")
+    if not FreeCAD.GuiUp:
+        raise ValueError("Running macros requires the FreeCAD GUI.")
+
+    res = dispatch_to_gui(lambda: QtCore.QTimer.singleShot(0, lambda: _execute(path)))
+    if isinstance(res, dict) and not res.get("success", True):
+        return res
+
+    FreeCADGui.updateGui()
+    return {
+        "success": True,
+        "name": os.path.basename(path),
+        "path": path,
+        "detached": True,
+        "message": (
+            "It runs detached, so this call cannot report its result; if it opens "
+            "a dialog it is now waiting for input. Use get_objects to see what it "
+            "created."
+        ),
+    }

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -20,6 +20,7 @@ from rpc_server.gui_dispatch import (
     process_gui_tasks,
     request_shutdown,
 )
+from rpc_server import macros
 from rpc_server.ip_filter import FilteredXMLRPCServer, validate_allowed_ips
 from rpc_server.object_factory import create_object_gui
 from rpc_server.parts_library import get_parts_list, insert_part_from_library
@@ -43,6 +44,21 @@ def _err(res) -> dict:
     if isinstance(res, dict):
         return res
     return {"success": False, "error": str(res)}
+
+
+def _macro_call(func, *args) -> dict:
+    """Run a macro helper, turning its exceptions into a failure dict.
+
+    Left to itself, an exception here crosses XML-RPC as a Fault and reaches
+    the caller as a transport error rather than a readable message. The macro
+    helpers raise ValueError for every user-correctable problem (bad name,
+    missing file, ambiguous edit), so those become ordinary results.
+    """
+    try:
+        return func(*args)
+    except Exception as e:
+        FreeCAD.Console.PrintError(f"MCP macro error: {type(e).__name__}: {e}\n")
+        return {"success": False, "error": str(e)}
 
 
 class FreeCADRPC:
@@ -206,6 +222,25 @@ class FreeCADRPC:
         if _ok(res):
             return {"success": True, "message": "Part inserted from library."}
         return _err(res)
+
+    # --- Macros -------------------------------------------------------
+    # Authoring is plain file I/O and safe on the RPC thread; only run_macro
+    # needs the GUI thread, and it manages that itself.
+
+    def list_macros(self):
+        return _macro_call(macros.list_macros)
+
+    def get_macro(self, name):
+        return _macro_call(macros.get_macro, name)
+
+    def create_macro(self, name, code, overwrite=False):
+        return _macro_call(macros.create_macro, name, code, overwrite)
+
+    def edit_macro(self, name, old_string, new_string, replace_all=False):
+        return _macro_call(macros.edit_macro, name, old_string, new_string, replace_all)
+
+    def run_macro(self, name):
+        return _macro_call(macros.run_macro, name)
 
     def list_documents(self):
         return list(FreeCAD.listDocuments().keys())

--- a/src/freecad_mcp/freecad_client.py
+++ b/src/freecad_mcp/freecad_client.py
@@ -96,6 +96,23 @@ class FreeCADConnection:
     def list_documents(self) -> list[str]:
         return self.server.list_documents()
 
+    def list_macros(self) -> dict[str, Any]:
+        return self.server.list_macros()
+
+    def get_macro(self, name: str) -> dict[str, Any]:
+        return self.server.get_macro(name)
+
+    def create_macro(self, name: str, code: str, overwrite: bool = False) -> dict[str, Any]:
+        return self.server.create_macro(name, code, overwrite)
+
+    def edit_macro(
+        self, name: str, old_string: str, new_string: str, replace_all: bool = False
+    ) -> dict[str, Any]:
+        return self.server.edit_macro(name, old_string, new_string, replace_all)
+
+    def run_macro(self, name: str) -> dict[str, Any]:
+        return self.server.run_macro(name)
+
     def run_fem_analysis(self, doc_name: str, analysis_name: str, timeout: int = 600) -> dict[str, Any]:
         # The solver blocks the RPC response for up to `timeout` seconds, so the
         # socket must outlast it. The default 150 s transport timeout would abort

--- a/src/freecad_mcp/operations/__init__.py
+++ b/src/freecad_mcp/operations/__init__.py
@@ -14,8 +14,20 @@ from .core import (
     reload_document_operation,
     run_fem_analysis_operation,
 )
+from .macros import (
+    create_macro_operation,
+    edit_macro_operation,
+    get_macro_operation,
+    list_macros_operation,
+    run_macro_operation,
+)
 
 __all__ = [
+    "create_macro_operation",
+    "edit_macro_operation",
+    "get_macro_operation",
+    "list_macros_operation",
+    "run_macro_operation",
     "create_document_operation",
     "create_object_operation",
     "delete_object_operation",

--- a/src/freecad_mcp/operations/macros.py
+++ b/src/freecad_mcp/operations/macros.py
@@ -1,0 +1,91 @@
+"""Operations backing the macro authoring and execution tools.
+
+Kept out of ``core`` because macros are a self-contained capability: they
+touch files in the user macro directory rather than the document tree, and
+none of them need a screenshot.
+"""
+
+import logging
+
+from ..freecad_client import FreeCADConnection
+from ..responses import ToolResponse, json_response, text_response
+
+
+logger = logging.getLogger("FreeCADMCPserver")
+
+
+def _failed(action: str, res: object) -> ToolResponse | None:
+    """Render a failure result, or None when the call succeeded."""
+    if isinstance(res, dict) and res.get("success"):
+        return None
+    error = res.get("error", res) if isinstance(res, dict) else res
+    return text_response(f"Failed to {action}: {error}")
+
+
+def list_macros_operation(freecad: FreeCADConnection) -> ToolResponse:
+    try:
+        res = freecad.list_macros()
+        if (failure := _failed("list macros", res)) is not None:
+            return failure
+        return json_response(
+            {"macro_dir": res.get("macro_dir"), "macros": res.get("macros", [])}
+        )
+    except Exception as e:
+        logger.error(f"Failed to list macros: {str(e)}")
+        return text_response(f"Failed to list macros: {str(e)}")
+
+
+def get_macro_operation(freecad: FreeCADConnection, name: str) -> ToolResponse:
+    try:
+        res = freecad.get_macro(name)
+        if (failure := _failed(f"read macro '{name}'", res)) is not None:
+            return failure
+        return text_response(res["code"])
+    except Exception as e:
+        logger.error(f"Failed to read macro: {str(e)}")
+        return text_response(f"Failed to read macro '{name}': {str(e)}")
+
+
+def create_macro_operation(
+    freecad: FreeCADConnection, name: str, code: str, overwrite: bool = False
+) -> ToolResponse:
+    try:
+        res = freecad.create_macro(name, code, overwrite)
+        if (failure := _failed(f"create macro '{name}'", res)) is not None:
+            return failure
+        return text_response(
+            f"Macro '{res['name']}' written ({res['bytes']} bytes) to {res['path']}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to create macro: {str(e)}")
+        return text_response(f"Failed to create macro '{name}': {str(e)}")
+
+
+def edit_macro_operation(
+    freecad: FreeCADConnection,
+    name: str,
+    old_string: str,
+    new_string: str,
+    replace_all: bool = False,
+) -> ToolResponse:
+    try:
+        res = freecad.edit_macro(name, old_string, new_string, replace_all)
+        if (failure := _failed(f"edit macro '{name}'", res)) is not None:
+            return failure
+        return text_response(
+            f"Macro '{res['name']}' edited ({res['replacements']} replacement(s))"
+        )
+    except Exception as e:
+        logger.error(f"Failed to edit macro: {str(e)}")
+        return text_response(f"Failed to edit macro '{name}': {str(e)}")
+
+
+def run_macro_operation(freecad: FreeCADConnection, name: str) -> ToolResponse:
+    try:
+        res = freecad.run_macro(name)
+        if (failure := _failed(f"run macro '{name}'", res)) is not None:
+            return failure
+        return text_response(f"Macro '{res['name']}' started. {res['message']}")
+    except Exception as e:
+        logger.error(f"Failed to run macro: {str(e)}")
+        return text_response(f"Failed to run macro '{name}': {str(e)}")

--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -15,7 +15,12 @@ from mcp.types import ImageContent, TextContent
 from .freecad_client import FreeCADConnection
 from .operations import (
     create_document_operation,
+    create_macro_operation,
     create_object_operation,
+    edit_macro_operation,
+    get_macro_operation,
+    list_macros_operation,
+    run_macro_operation,
     delete_object_operation,
     edit_object_operation,
     execute_code_async_operation,
@@ -504,6 +509,105 @@ def run_fem_analysis(
         analysis_name,
         timeout,
     )
+
+
+@mcp.tool()
+def list_macros(ctx: Context) -> list[TextContent]:
+    """List the macros in FreeCAD's user macro directory.
+
+    Returns the directory path plus each macro's name, size and docstring
+    summary line. Use this to discover what exists before creating or editing.
+    """
+    return list_macros_operation(get_freecad_connection())
+
+
+@mcp.tool()
+def get_macro(ctx: Context, name: str) -> list[TextContent]:
+    """Read the full source of a macro.
+
+    Args:
+        name: Macro name, with or without the '.FCMacro' suffix.
+    """
+    return get_macro_operation(get_freecad_connection(), name)
+
+
+@mcp.tool()
+def create_macro(
+    ctx: Context, name: str, code: str, overwrite: bool = False
+) -> list[TextContent]:
+    """Write a new macro into FreeCAD's user macro directory.
+
+    A macro is a plain Python file that FreeCAD lists under Macro -> Macros...
+    and can run independently of this MCP. Note the macro directory is
+    whatever the user configured, which may be a cloud-synced folder.
+
+    A GUI macro conventionally builds a QDialog for input, then hands a plain
+    dict to a separate geometry function. Keeping those two apart is worth
+    doing: it lets the same file serve both a human at the dialog and any
+    caller that already knows the values.
+
+    Args:
+        name: Macro name; '.FCMacro' is appended if absent.
+        code: Complete Python source of the macro.
+        overwrite: Replace an existing macro of the same name (default False).
+                   To change part of a macro, prefer edit_macro.
+
+    Examples:
+        ```json
+        {
+            "name": "my_bracket",
+            "code": "import FreeCAD as App\\n# ...\\n"
+        }
+        ```
+    """
+    return create_macro_operation(get_freecad_connection(), name, code, overwrite)
+
+
+@mcp.tool()
+def edit_macro(
+    ctx: Context,
+    name: str,
+    old_string: str,
+    new_string: str,
+    replace_all: bool = False,
+) -> list[TextContent]:
+    """Replace an exact substring inside an existing macro.
+
+    Preferred over rewriting a macro with create_macro(overwrite=True):
+    macros can be very large, and a targeted replacement neither costs a full
+    round-trip nor risks dropping parts of the file.
+
+    Fails if old_string is absent, or if it appears more than once and
+    replace_all is False -- include surrounding lines to disambiguate.
+
+    Args:
+        name: Macro name, with or without the '.FCMacro' suffix.
+        old_string: Exact text to find, including indentation.
+        new_string: Replacement text.
+        replace_all: Replace every occurrence instead of requiring a unique match.
+    """
+    return edit_macro_operation(
+        get_freecad_connection(), name, old_string, new_string, replace_all
+    )
+
+
+@mcp.tool()
+def run_macro(ctx: Context, name: str) -> list[TextContent]:
+    """Start a macro in FreeCAD, without waiting for it to finish.
+
+    The macro runs detached, so this returns as soon as it has been started
+    and CANNOT report what the macro did. If the macro opens a dialog, it is
+    left waiting for the user. Call get_objects afterwards to see what was
+    created.
+
+    Do not try to run a macro via execute_code (a modal dialog would block
+    the server until dismissed) or execute_code_async (Qt widgets cannot be
+    created off the GUI thread).
+
+    Args:
+        name: Macro name, with or without the '.FCMacro' suffix.
+    """
+    return run_macro_operation(get_freecad_connection(), name)
 
 
 @mcp.prompt()


### PR DESCRIPTION
## Summary

Adds a general capability for creating and running FreeCAD macros through the MCP: `list_macros`, `get_macro`, `create_macro`, `edit_macro` and `run_macro`.

Nothing here ships or assumes any particular macro — what a macro does inside is entirely the macro author's business. Macros written this way are ordinary `.FCMacro` files: they appear under **Macro → Macros…** and run perfectly well with the MCP not involved at all.

Authoring is deliberately separate from execution. They have different properties: authoring is file I/O that always returns a definite result, while execution is fire-and-forget into a GUI event loop and *cannot* report what the macro did.

## Design decisions worth reviewing

**Authoring runs on the RPC thread, not the GUI thread.** It is plain file I/O against `FreeCAD.getUserMacroDir()`, so it needs no dispatch. A useful side effect: `list_macros` still answers while a modal dialog has the GUI thread blocked, which would not be true had it been routed through `dispatch_to_gui` for consistency.

**`edit_macro` replaces an exact substring rather than rewriting the file.** Real macro libraries contain 100 kB files, and round-tripping one through a model to change a single value invites it to silently drop the parts it only half-remembers. A non-matching edit now fails loudly, and an ambiguous one asks for more context instead of guessing — the same contract as a normal editing tool.

**Macro names are restricted to plain file names and re-checked with `realpath` after resolution.** These helpers write files that `run_macro` then executes as Python, so escaping the macro directory has to be impossible rather than merely unlikely. This adds no privilege the MCP lacks — `execute_code` already runs arbitrary Python — but a path-traversal *write* is a different and worse thing than an in-directory one.

**`run_macro` is detached, and that is forced by this server's design rather than chosen.** Neither existing tool can correctly run a GUI macro:

| | thread | problem |
|---|---|---|
| `execute_code` | GUI thread ✅ | `dialog.exec()` blocks it; worse, `process_gui_tasks` skips every tick while `activeModalWidget()` is set (`gui_dispatch.py:118`), so awaiting a macro stalls the whole dispatch loop until a human dismisses the dialog |
| `execute_code_async` | background thread ❌ | returns immediately, but Qt widgets may only be constructed on the GUI thread |

So `run_macro` hops to the GUI thread purely to arm a zero-delay timer and returns at once — correct thread affinity, no blocking. The corollary is that it cannot report what the macro did; callers use `get_objects`. Both constraints are stated in the tool description so a model does not reach for the wrong tool.

`_execute` uses `compile()`/`exec()` rather than the import machinery, which matters twice: `.FCMacro` is not a recognised Python suffix (so `spec_from_file_location` returns `None`), and the common macro idiom guards its entry point with `if __name__ == '__main__'`, which only fires if `__name__` is set accordingly.

## Verification

Tested against FreeCAD 1.1.3.

With the macro directory redirected to a scratch dir:

- create / overwrite / no-clobber / list / get behave as specified
- `edit_macro` succeeds on a unique match; rejects missing and ambiguous ones
- six traversal and malformed names (`../../.bashrc`, `/etc/passwd`, `a/b`, `.hidden`, …) all refused
- executing a macro honours the `if __name__ == '__main__'` guard and picks up a prior `edit_macro` change

End-to-end against a real macro directory, driving the tools over the same XML-RPC transport `freecad_client.py` uses:

- `list_macros` enumerated an existing 47-macro library with docstring summaries
- `create_macro` wrote a new GUI macro, which `run_macro` then started in **18 ms** — shorter than one 500 ms heartbeat tick, confirming the immediate-wake signal path fired and that the call did not wait on the dialog
- the macro's dialog was driven by hand and produced correct solids (volume matched `pi*(R_o^2-R_i^2)*L` exactly for two different diameters)
- the configured stdio server reports 19 tools, and a `tools/call` of `list_macros` returns the real directory listing

No new dependencies. This is independent of #100 and branches from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
