### PR TITLE
fix: stop sending every screenshot twice via structuredContent

### DIFF
--- a/src/freecad_mcp/server.py
+++ b/src/freecad_mcp/server.py
@@ -83,7 +83,7 @@ def get_freecad_connection() -> FreeCADConnection:
     return state.freecad_connection
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def create_document(ctx: Context, name: str) -> list[TextContent]:
     """Create a new document in FreeCAD.
 
@@ -104,7 +104,7 @@ def create_document(ctx: Context, name: str) -> list[TextContent]:
     return create_document_operation(get_freecad_connection(), name)
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def create_object(
     ctx: Context,
     doc_name: str,
@@ -240,7 +240,7 @@ def create_object(
     )
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def edit_object(
     ctx: Context, doc_name: str, obj_name: str, obj_properties: dict[str, Any]
 ) -> list[TextContent | ImageContent]:
@@ -264,7 +264,7 @@ def edit_object(
     )
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def delete_object(ctx: Context, doc_name: str, obj_name: str) -> list[TextContent | ImageContent]:
     """Delete an object in FreeCAD.
 
@@ -283,7 +283,7 @@ def delete_object(ctx: Context, doc_name: str, obj_name: str) -> list[TextConten
     )
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def execute_code_async(ctx: Context, code: str) -> list[TextContent]:
     """Execute Python code in FreeCAD without waiting for completion.
 
@@ -322,7 +322,7 @@ def execute_code_async(ctx: Context, code: str) -> list[TextContent]:
     return execute_code_async_operation(get_freecad_connection(), code)
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def execute_code(ctx: Context, code: str) -> list[TextContent | ImageContent]:
     """Execute arbitrary Python code in FreeCAD.
 
@@ -335,7 +335,7 @@ def execute_code(ctx: Context, code: str) -> list[TextContent | ImageContent]:
     return execute_code_operation(get_freecad_connection(), state.only_text_feedback, code)
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def get_view(
     ctx: Context,
     view_name: Literal["Isometric", "Front", "Top", "Right", "Back", "Left", "Bottom", "Dimetric", "Trimetric"],
@@ -367,7 +367,7 @@ def get_view(
     return get_view_operation(get_freecad_connection(), view_name, width, height, focus_object)
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def insert_part_from_library(ctx: Context, relative_path: str) -> list[TextContent | ImageContent]:
     """Insert a part from the parts library addon.
 
@@ -384,7 +384,7 @@ def insert_part_from_library(ctx: Context, relative_path: str) -> list[TextConte
     )
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def get_objects(ctx: Context, doc_name: str) -> list[TextContent | ImageContent]:
     """Get all objects in a document.
     You can use this tool to get the objects in a document to see what you can check or edit.
@@ -398,7 +398,7 @@ def get_objects(ctx: Context, doc_name: str) -> list[TextContent | ImageContent]
     return get_objects_operation(get_freecad_connection(), state.only_text_feedback, doc_name)
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def get_object(ctx: Context, doc_name: str, obj_name: str) -> list[TextContent | ImageContent]:
     """Get an object from a document.
     You can use this tool to get the properties of an object to see what you can check or edit.
@@ -418,14 +418,14 @@ def get_object(ctx: Context, doc_name: str, obj_name: str) -> list[TextContent |
     )
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def get_parts_list(ctx: Context) -> list[TextContent]:
     """Get the list of parts in the parts library addon.
     """
     return get_parts_list_operation(get_freecad_connection())
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def reload_document(ctx: Context, doc_name: str) -> list[TextContent]:
     """Close and re-open a document to pick up external file changes.
 
@@ -454,7 +454,7 @@ def reload_document(ctx: Context, doc_name: str) -> list[TextContent]:
     return reload_document_operation(get_freecad_connection(), doc_name)
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def list_documents(ctx: Context) -> list[TextContent]:
     """Get the list of open documents in FreeCAD.
 
@@ -464,7 +464,7 @@ def list_documents(ctx: Context) -> list[TextContent]:
     return list_documents_operation(get_freecad_connection())
 
 
-@mcp.tool()
+@mcp.tool(structured_output=False)
 def run_fem_analysis(
     ctx: Context,
     doc_name: str,


### PR DESCRIPTION
Every screenshot this server returns is currently sent to the client twice — once as an image content block, and once as raw base64 text. The duplicate costs roughly 25x the image it duplicates.

I found this while profiling a real session: a few agents driving this server to build a parametric enclosure. The numbers below are measured from those transcripts.

## What's happening

Every tool here is annotated `-> list[TextContent | ImageContent]`. FastMCP generates an output schema for any tool whose return annotation isn't `str`, then serialises the entire return value into `structuredContent` alongside the normal content blocks. So each result carries the screenshot as a real image block *and* as base64 inside a `{"result": [...]}` JSON blob.

It's visible in the transcripts — every `execute_code` result has an image block and a text block of near-identical size:

```
imgbytes=39068 textbytes=39737
imgbytes=48964 textbytes=49624
imgbytes=56996 textbytes=57699
```

Reproducible in isolation:

```python
@m.tool()
def a(x: int) -> list[TextContent | ImageContent]: ...
# -> ([TextContent, ImageContent], {'result': [..., {'data': 'BASE64BLOB', ...}]})

@m.tool(structured_output=False)
def b(x: int) -> list[TextContent | ImageContent]: ...
# -> [TextContent, ImageContent]
```

## Why it's expensive

Base64 of a compressed PNG is effectively random, so it tokenises at roughly one token per character. Measured against a 1932x1246 view, a single `execute_code` call added **~53,000 tokens** to the client's context:

```
turn ctx=  80993  (+54682)
turn ctx= 133006  (+52013)
turn ctx= 190761  (+54860)
turn ctx= 244711  (+53950)
turn ctx= 298592  (+53233)
```

About 2,100 of that is the image block. The other ~51,000 is the duplicate — content no client renders, since clients consume the content blocks. And because it lands in ordinary context, it's re-read on every subsequent turn, so the cost compounds.

Across the session I profiled: 66 tool calls, 57 screenshots, **~3 MB of duplicated base64 ≈ 800k wasted tokens**, contributing to 49.7M cache-read tokens overall. One agent made 26 `execute_code` calls and burned 22.3M cache-read tokens by itself.

## The change

`structured_output=False` on the 14 tool decorators. This suppresses the generated output schema and the duplicate payload. The content blocks clients actually consume are byte-identical — nothing about the tools' behaviour or return values changes.

Verified after the change: all 14 tools list with `outputSchema: None`.

## Tested on both SDK majors

`pyproject.toml` allows `mcp[cli]>=1.12.2,<3`, and 2.0.0 is the current release — so a fresh `uvx freecad-mcp` install resolves to 2.x today. I tested both, since the fallback import path at `server.py:5-12` means the same source runs against either.

Behaviour is identical on **mcp 1.13.0** and **mcp 2.0.0**:

| branch | tools listed | declaring an output schema |
|---|---|---|
| `main` | 14 | all 14 |
| this PR | 14 | none |

End-to-end through a real `ClientSession` on 2.0.0, with a stand-in base64 blob:

```
 current: outputSchema=yes content=['text', 'image'] structuredContent=present blob_duplicated=True
 patched: outputSchema=no  content=['text', 'image'] structuredContent=None    blob_duplicated=False
```

The `content` blocks are identical either way — only the duplicate goes away. `structured_output` is a documented `tool()` kwarg on both `mcp.server.fastmcp.FastMCP` (1.x) and `mcp.server.mcpserver.MCPServer` (2.x), so no version-conditional handling is needed.

## Related

Complementary to #80 (per-call `include_screenshot`) — that reduces how many screenshots get sent, this reduces what each one costs. Neither subsumes the other, and they touch different lines.
