### PR TITLE
perf: cap auto-sized screenshots at a 1024px long edge

### DIFF
--- a/addon/FreeCADMCP/rpc_server/view_manager.py
+++ b/addon/FreeCADMCP/rpc_server/view_manager.py
@@ -31,12 +31,30 @@ def _get_view_size(view: Any) -> tuple[int, int]:
         return 1024, 768
 
 
+# Longest edge used when the caller does not ask for a specific size. The
+# screenshot's cost to an LLM client scales with its pixel count, and hosts
+# commonly downscale anything larger than ~1.5k px before the model ever sees
+# it, so rendering at the full window size just inflates the payload. An
+# explicit width/height is always honoured as given.
+MAX_AUTO_SCREENSHOT_EDGE = 1024
+
+
+def _scale_to_max_edge(width: int, height: int, max_edge: int) -> tuple[int, int]:
+    longest = max(width, height)
+    if longest <= max_edge:
+        return width, height
+    scale = max_edge / longest
+    return max(1, int(width * scale)), max(1, int(height * scale))
+
+
 def _resolve_screenshot_size(
     view: Any,
     width: int | None,
     height: int | None,
 ) -> tuple[int, int]:
     view_width, view_height = _get_view_size(view)
+    if width is None and height is None:
+        return _scale_to_max_edge(view_width, view_height, MAX_AUTO_SCREENSHOT_EDGE)
     resolved_width = view_width if width is None else max(1, int(width))
     resolved_height = view_height if height is None else max(1, int(height))
     return resolved_width, resolved_height


### PR DESCRIPTION
When no explicit width/height is requested, `_resolve_screenshot_size` renders at the live FreeCAD window size. On a maximised window that's ~1932x1246, which costs an LLM client roughly 2.1k tokens per image — and hosts commonly downscale anything past ~1.5k px before the model ever sees it, so a good share of those pixels are paid for in transfer and then discarded.

I hit this profiling a real modelling session, where every auto-sized screenshot came back at 1932x1246.

## The change

Scale the auto-derived size down to a 1024px long edge, preserving aspect ratio (~900 tokens, and CAD geometry stays legible at that size).

| view size | requested | result |
|---|---|---|
| 1932x1246 | — | 1024x660 |
| 800x600 | — | 800x600 (already under the cap, untouched) |
| 1932x1246 | 700x700 | 700x700 (honoured) |
| 1932x1246 | 2000 x — | 2000x1246 (honoured) |

An explicit width or height is always honoured exactly as given, so `get_view` callers who deliberately want a large render still get one. Only the implicit "whatever the window happens to be" path is capped.

The cap is a module constant (`MAX_AUTO_SCREENSHOT_EDGE`) if you'd prefer a different default — 1024 seemed a reasonable balance, but I don't have strong feelings about the exact number.

## Related

Complementary to #80 (per-call `include_screenshot`) — that reduces how many screenshots get sent, this reduces the size of the ones that are. They touch different files.
