### PR TITLE
fix(rpc): guard serialize_shape against invalid shapes

### DIFF
--- a/addon/FreeCADMCP/rpc_server/serialize.py
+++ b/addon/FreeCADMCP/rpc_server/serialize.py
@@ -40,13 +40,16 @@ def serialize_value(value):
 def serialize_shape(shape):
     if shape is None:
         return None
-    return {
-        "Volume": shape.Volume,
-        "Area": shape.Area,
-        "VertexCount": len(shape.Vertexes),
-        "EdgeCount": len(shape.Edges),
-        "FaceCount": len(shape.Faces),
-    }
+    try:
+        return {
+            "Volume": shape.Volume,
+            "Area": shape.Area,
+            "VertexCount": len(shape.Vertexes),
+            "EdgeCount": len(shape.Edges),
+            "FaceCount": len(shape.Faces),
+        }
+    except Exception as e:
+        return {"error": f"invalid shape: {str(e)}"}
 
 
 def serialize_view_object(view):

--- a/tests/test_serialize_shape.py
+++ b/tests/test_serialize_shape.py
@@ -1,0 +1,92 @@
+"""Regression test: one invalid shape must not break the whole document serialization.
+
+See https://github.com/neka-nat/freecad-mcp/issues/109
+"""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+# --- Stub FreeCAD so serialize.py can be imported without a FreeCAD install ---
+freecad_stub = types.ModuleType("FreeCAD")
+
+
+class _StubVector:
+    def __init__(self, x=0.0, y=0.0, z=0.0):
+        self.x, self.y, self.z = x, y, z
+
+
+class _StubRotation:
+    Axis = _StubVector(0, 0, 1)
+    Angle = 0.0
+
+
+class _StubPlacement:
+    Base = _StubVector()
+    Rotation = _StubRotation()
+
+
+class _BrokenShape:
+    """Shape whose compute failed: every attribute read raises RuntimeError."""
+
+    def __getattr__(self, name):
+        raise RuntimeError("shape is invalid")
+
+
+class _GoodShape:
+    Volume = 42.0
+    Area = 10.0
+    Vertexes = [object() for _ in range(8)]
+    Edges = [object() for _ in range(6)]
+    Faces = [object() for _ in range(4)]
+
+
+freecad_stub.Vector = _StubVector
+freecad_stub.Rotation = _StubRotation
+freecad_stub.Placement = _StubPlacement
+
+
+class _StubDocument:
+    Name = "Doc"
+    Label = "Doc"
+    FileName = ""
+    Objects = []
+
+
+freecad_stub.Document = _StubDocument
+sys.modules["FreeCAD"] = freecad_stub
+
+serialize_path = Path(__file__).resolve().parents[1] / "addon" / "FreeCADMCP"
+sys.path.insert(0, str(serialize_path))
+serialize = importlib.import_module("rpc_server.serialize")
+
+
+def test_good_shape_serializes():
+    result = serialize.serialize_shape(_GoodShape())
+    assert result["Volume"] == 42.0
+    assert result["VertexCount"] == 8
+
+
+def test_broken_shape_returns_error_dict_instead_of_raising():
+    result = serialize.serialize_shape(_BrokenShape())
+    assert "error" in result
+    assert "invalid shape" in result["error"]
+
+
+def test_none_shape_returns_none():
+    assert serialize.serialize_shape(None) is None
+
+
+def test_serialize_object_survives_broken_shape():
+    obj = types.SimpleNamespace(
+        Name="Pad",
+        Label="Pad",
+        TypeId="PartDesign::Pad",
+        PropertiesList=[],
+        Placement=_StubPlacement(),
+        Shape=_BrokenShape(),
+    )
+    result = serialize.serialize_object(obj)
+    assert result["Name"] == "Pad"
+    assert "error" in result["Shape"]


### PR DESCRIPTION
### Problem

`get_objects()` and `get_object()` fail with an XML-RPC Fault when any object in the document has a shape that failed to compute. `serialize_shape()` reads `shape.Volume` with no guard, and FreeCAD raises `RuntimeError: shape is invalid` on every attribute access of a broken shape. That exception escapes `serialize_object` and aborts the whole call, so one bad object makes the entire document unreadable.

This is worse than it sounds because the asset-creation prompt tells models to start every task with `get_objects()`. A single broken `PartDesign::Pad` means the model cannot inspect the document, cannot see what failed, and cannot recover, while `create_object` keeps reporting `success: True`.

### Fix

Wrap the shape serialization in a try/except and return an error dict for the broken shape instead of propagating. Healthy objects still serialize normally, and the caller can see exactly which shape is invalid and why. This matches the guard pattern already used for the per-property loop in `serialize_object`.

```python
except Exception as e:
    return {"error": f"invalid shape: {str(e)}"}
```

The `None` early-return is unchanged, so objects without a shape are unaffected.

### How to Test

1. Create an object whose shape fails to compute (e.g. a `PartDesign::Pad` without a valid sketch, or any object that raises on `Shape.Volume`).
2. Call `get_objects()` — before the fix it returns `Fault 1: <class 'RuntimeError'>: shape is invalid` for the whole document. After the fix the broken object's `Shape` field contains `{"error": "invalid shape: ..."}` and every other object serializes normally.

Regression tests are in `tests/test_serialize_shape.py` with stubbed FreeCAD types so they run without a FreeCAD install:

```
uv run --no-project python -m pytest tests/test_serialize_shape.py -q
```

Without the fix, `test_broken_shape_returns_error_dict_instead_of_raising` and `test_serialize_object_survives_broken_shape` fail with the exact `RuntimeError` from the issue. With the fix, all 4 pass.

Closes #109
