### PR TITLE
fix(rpc_server): use Framebuffer saveImage to fix Wayland get_view

### DIFF
--- a/addon/FreeCADMCP/rpc_server/view_manager.py
+++ b/addon/FreeCADMCP/rpc_server/view_manager.py
@@ -144,7 +144,14 @@ def save_active_screenshot(
         else:
             view.fitAll()
         resolved_width, resolved_height = _resolve_screenshot_size(view, width, height)
-        view.saveImage(save_path, resolved_width, resolved_height, "Current")
+        # On Wayland the offscreen GL contexts used by the default saveImage()
+        # method render solid black; "Framebuffer" reads back the on-screen GL
+        # context and captures correctly (and also works on X11/Windows/macOS).
+        # FreeCAD < 1.0 lacks the method argument — fall back to the legacy call.
+        try:
+            view.saveImage(save_path, resolved_width, resolved_height, "Current", "Framebuffer")
+        except TypeError:
+            view.saveImage(save_path, resolved_width, resolved_height, "Current")
 
         if focused_selection:
             FreeCADGui.Selection.clearSelection()


### PR DESCRIPTION
This PR addresses blank image issue with get_view on Wayland(also reproducible on native FreeCAD "Save Image..." dialog - not working without "Extended" setting).