### PR TITLE
fix(rpc): constrain insert_part_from_library to the parts library

### DIFF
--- a/addon/FreeCADMCP/rpc_server/parts_library.py
+++ b/addon/FreeCADMCP/rpc_server/parts_library.py
@@ -6,7 +6,13 @@ import FreeCADGui
 
 def insert_part_from_library(relative_path):
     parts_lib_path = os.path.join(FreeCAD.getUserAppDataDir(), "Mod", "parts_library")
-    part_path = os.path.join(parts_lib_path, relative_path)
+    parts_lib_real = os.path.realpath(parts_lib_path)
+    part_path = os.path.realpath(os.path.join(parts_lib_path, relative_path))
+
+    # os.path.join drops parts_lib_path for an absolute relative_path, and
+    # neither join nor realpath rejects a ".." that walks outside it.
+    if os.path.commonpath([part_path, parts_lib_real]) != parts_lib_real:
+        raise ValueError(f"relative_path escapes the parts library: {relative_path}")
 
     if not os.path.exists(part_path):
         raise FileNotFoundError(f"Not found: {part_path}")

--- a/tests/test_parts_library.py
+++ b/tests/test_parts_library.py
@@ -1,0 +1,94 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from contextlib import contextmanager
+from typing import Iterator
+
+import pytest
+
+ADDON_DIR = Path(__file__).resolve().parents[1] / "addon" / "FreeCADMCP"
+PARTS_LIBRARY_PATH = ADDON_DIR / "rpc_server" / "parts_library.py"
+if str(ADDON_DIR) not in sys.path:
+    sys.path.insert(0, str(ADDON_DIR))
+
+
+class FakeDocument:
+    def __init__(self) -> None:
+        self.merged: list[str] = []
+
+    def mergeProject(self, part_path: str) -> None:
+        self.merged.append(part_path)
+
+
+@contextmanager
+def load_parts_library(app_data_dir: str) -> Iterator[tuple[types.ModuleType, FakeDocument]]:
+    module_names = ["FreeCAD", "FreeCADGui"]
+    missing = object()
+    saved = {name: sys.modules.get(name, missing) for name in module_names}
+
+    freecad = types.ModuleType("FreeCAD")
+    freecad.getUserAppDataDir = lambda: app_data_dir
+    freecad.newDocument = lambda: None
+
+    active_document = FakeDocument()
+    freecad_gui = types.ModuleType("FreeCADGui")
+    freecad_gui.ActiveDocument = active_document
+
+    sys.modules["FreeCAD"] = freecad
+    sys.modules["FreeCADGui"] = freecad_gui
+
+    module_name = f"_parts_library_test_{id(app_data_dir)}"
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, PARTS_LIBRARY_PATH)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load parts_library from {PARTS_LIBRARY_PATH}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        yield module, active_document
+    finally:
+        sys.modules.pop(module_name, None)
+        for name, value in saved.items():
+            if value is missing:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+def test_absolute_relative_path_is_rejected(tmp_path):
+    app_data_dir = tmp_path / "AppData"
+    parts_lib = app_data_dir / "Mod" / "parts_library"
+    parts_lib.mkdir(parents=True)
+    secret = tmp_path / "secret.FCStd"
+    secret.write_text("not a real FCStd file")
+
+    with load_parts_library(str(app_data_dir)) as (module, active_document):
+        with pytest.raises(ValueError):
+            module.insert_part_from_library(str(secret))
+        assert active_document.merged == []
+
+
+def test_dotdot_relative_path_is_rejected(tmp_path):
+    app_data_dir = tmp_path / "AppData"
+    parts_lib = app_data_dir / "Mod" / "parts_library"
+    parts_lib.mkdir(parents=True)
+    secret = tmp_path / "secret.FCStd"
+    secret.write_text("not a real FCStd file")
+
+    with load_parts_library(str(app_data_dir)) as (module, active_document):
+        with pytest.raises(ValueError):
+            module.insert_part_from_library("../../../secret.FCStd")
+        assert active_document.merged == []
+
+
+def test_relative_path_within_library_still_works(tmp_path):
+    app_data_dir = tmp_path / "AppData"
+    parts_lib = app_data_dir / "Mod" / "parts_library"
+    (parts_lib / "bolts").mkdir(parents=True)
+    part = parts_lib / "bolts" / "m3.FCStd"
+    part.write_text("not a real FCStd file")
+
+    with load_parts_library(str(app_data_dir)) as (module, active_document):
+        module.insert_part_from_library("bolts/m3.FCStd")
+        assert active_document.merged == [str(part)]


### PR DESCRIPTION
## Root cause

`insert_part_from_library`'s `relative_path` argument is an LLM-callable MCP tool
parameter, and it reaches `os.path.join(parts_lib_path, relative_path)` with no
containment check. `os.path.join` silently discards `parts_lib_path` when
`relative_path` is absolute, and neither `join` nor a later `realpath` rejects a
`../` sequence that walks outside the library. Either shape lets the tool call
`FreeCADGui.ActiveDocument.mergeProject()` on any `.FCStd` file readable by the
FreeCAD process, not just files under `parts_library`.

## Fix

Resolve both the library root and the joined path with `os.path.realpath`, then
require the resolved part path's common path with the resolved root to be the
root itself before touching the filesystem. This mirrors the containment
`get_parts_list` already gets for free from `os.walk(parts_lib_path)`.

## Verification

- `tests/test_parts_library.py` (new): an absolute path and a `../../../` path
  both raise `ValueError` and never call `mergeProject`; a legitimate path
  inside the library still resolves and calls `mergeProject` as before. All
  three fail on `main` (the traversal cases silently proceed to
  `FileNotFoundError`/success instead of being rejected) and pass on this
  branch, run both ways in a clean `python:3.12-slim` container.
- `uv run pytest -q`: 25 passed, on Python 3.12 and 3.13 (this repo's CI
  matrix), in clean containers.
- `uv lock --check` and `uv run python -m compileall src addon`: clean on both
  versions.
- Not checked: `FreeCADGui.ActiveDocument.mergeProject()`'s own behavior is not
  exercised, since FreeCAD is not installable in this environment. The fix and
  tests cover the path computation that feeds it, which is the entire
  containment gap; the merge call itself is unchanged.

Fixes #121
