### PR TITLE
fix(rpc): handle requests concurrently so get_rpc_status stays answer…

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ Tools that return a screenshot (`create_object`, `edit_object`, `delete_object`,
 
 If a GUI-thread operation exceeds its timeout after it has started, the bridge
 returns `GUI_DISPATCH_STUCK` and rejects later GUI operations immediately. Use
-`get_rpc_status` to identify the operation that is still running. FreeCAD GUI
+`get_rpc_status` to identify the operation that is still running; the RPC server
+handles each request in its own thread, so that status call is answered even while
+the stuck operation is still holding the GUI thread. FreeCAD GUI
 work cannot be force-cancelled safely; if the status does not return to
 `healthy` after the operation finishes, restart FreeCAD.
 

--- a/addon/FreeCADMCP/rpc_server/ip_filter.py
+++ b/addon/FreeCADMCP/rpc_server/ip_filter.py
@@ -2,13 +2,25 @@
 
 import ipaddress
 import re
+from socketserver import ThreadingMixIn
 from xmlrpc.server import SimpleXMLRPCServer
 
 import FreeCAD
 
 
-class FilteredXMLRPCServer(SimpleXMLRPCServer):
-    """XML-RPC server that filters connections by allowed IP addresses/subnets."""
+class FilteredXMLRPCServer(ThreadingMixIn, SimpleXMLRPCServer):
+    """XML-RPC server that filters connections by allowed IP addresses/subnets.
+
+    Threaded so get_rpc_status stays answerable while a wedged GUI task blocks
+    another request; handlers serialise onto the GUI thread through
+    dispatch_to_gui, so concurrency here is safe.
+
+    daemon_threads must stay true — ThreadingMixIn.server_close() joins
+    non-daemon request threads, which would make Stop wait out the stuck
+    operation.
+    """
+
+    daemon_threads = True
 
     def __init__(self, addr, allowed_ips_str="127.0.0.1", **kwargs):
         self._allowed_networks = _parse_allowed_ips(allowed_ips_str)

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -424,13 +424,11 @@ def stop_rpc_server():
     cleanup_waker()
 
     def _shutdown_and_close():
-        # shutdown() blocks until serve_forever drains the in-flight request,
-        # and that request may itself be waiting on dispatch_to_gui — running
-        # this on the GUI thread (menu command) froze the UI for up to the
-        # dispatch timeout. server_close() must always follow: without it the
-        # listening socket stays bound and Stop -> Start fails with
-        # EADDRINUSE (the restart the README asks for after changing Remote
-        # Connections or Allowed IPs).
+        # shutdown() only stops the accept loop; in-flight requests run in
+        # their own daemon threads and are not waited for. Kept off the GUI
+        # thread so a menu command cannot block the UI. server_close() must
+        # always follow, or the listening socket stays bound and Stop -> Start
+        # fails with EADDRINUSE.
         try:
             server.shutdown()
             if thread is not None:

--- a/tests/test_rpc_concurrency.py
+++ b/tests/test_rpc_concurrency.py
@@ -1,0 +1,156 @@
+from contextlib import contextmanager
+from pathlib import Path
+from socketserver import ThreadingMixIn
+import sys
+import threading
+import time
+import types
+from typing import Iterator
+import xmlrpc.client
+
+
+ADDON_DIR = Path(__file__).resolve().parents[1] / "addon" / "FreeCADMCP"
+if str(ADDON_DIR) not in sys.path:
+    sys.path.insert(0, str(ADDON_DIR))
+
+
+_filtered_server_class = None
+
+
+def filtered_server_class() -> type:
+    global _filtered_server_class
+    if _filtered_server_class is not None:
+        return _filtered_server_class
+
+    # ip_filter logs rejected connections through FreeCAD.Console and keeps its
+    # own reference after import, so the stub is withdrawn again right away.
+    saved = sys.modules.get("FreeCAD")
+    stub = types.ModuleType("FreeCAD")
+    stub.Console = types.SimpleNamespace(
+        PrintWarning=lambda _message: None, PrintError=lambda _message: None
+    )
+    sys.modules["FreeCAD"] = stub
+    try:
+        sys.modules.pop("rpc_server.ip_filter", None)
+        from rpc_server.ip_filter import FilteredXMLRPCServer
+    finally:
+        if saved is None:
+            sys.modules.pop("FreeCAD", None)
+        else:
+            sys.modules["FreeCAD"] = saved
+
+    _filtered_server_class = FilteredXMLRPCServer
+    return FilteredXMLRPCServer
+
+
+class WedgedGuiThread:
+    def __init__(self) -> None:
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def execute_code(self, code: str) -> dict:
+        self.entered.set()
+        self.release.wait(30)
+        return {"success": True, "message": code}
+
+    def get_rpc_status(self) -> dict:
+        return {
+            "success": True,
+            "rpc_server": "running",
+            "gui_dispatch": {"state": "stuck", "operation": "execute_code"},
+        }
+
+
+class _TimeoutTransport(xmlrpc.client.Transport):
+    def __init__(self, timeout: float):
+        super().__init__()
+        self._timeout = timeout
+
+    def make_connection(self, host):
+        connection = super().make_connection(host)
+        connection.timeout = self._timeout
+        return connection
+
+
+def client(host: str, port: int, timeout: float) -> xmlrpc.client.ServerProxy:
+    return xmlrpc.client.ServerProxy(
+        f"http://{host}:{port}", allow_none=True, transport=_TimeoutTransport(timeout)
+    )
+
+
+def build_server(interface: object):
+    server = filtered_server_class()(
+        ("127.0.0.1", 0), allowed_ips_str="127.0.0.1", allow_none=True, logRequests=False
+    )
+    server.register_instance(interface)
+    return server
+
+
+@contextmanager
+def running_server(interface: object) -> Iterator[tuple[str, int]]:
+    server = build_server(interface)
+    loop = threading.Thread(target=server.serve_forever, daemon=True)
+    loop.start()
+    try:
+        yield server.server_address
+    finally:
+        server.shutdown()
+        loop.join(timeout=5)
+        server.server_close()
+
+
+def test_request_threads_are_daemons_so_stop_does_not_join_them() -> None:
+    server_class = filtered_server_class()
+    assert issubclass(server_class, ThreadingMixIn)
+    assert server_class.daemon_threads is True
+
+
+def test_status_is_answered_while_execute_code_is_blocked() -> None:
+    interface = WedgedGuiThread()
+    with running_server(interface) as (host, port):
+        blocked = threading.Thread(
+            target=lambda: client(host, port, 30).execute_code("while True: pass"),
+            daemon=True,
+        )
+        blocked.start()
+        try:
+            assert interface.entered.wait(5)
+            status = client(host, port, 5).get_rpc_status()
+            assert status["gui_dispatch"]["state"] == "stuck"
+            assert status["gui_dispatch"]["operation"] == "execute_code"
+        finally:
+            interface.release.set()
+            blocked.join(timeout=10)
+
+
+def test_ip_filter_rejects_before_a_thread_is_spawned() -> None:
+    server = build_server(WedgedGuiThread())
+    try:
+        assert server.verify_request(None, ("127.0.0.1", 5000)) is True
+        assert server.verify_request(None, ("10.1.2.3", 5000)) is False
+    finally:
+        server.server_close()
+
+
+def test_stopping_does_not_wait_for_an_in_flight_request() -> None:
+    interface = WedgedGuiThread()
+    server = build_server(interface)
+    loop = threading.Thread(target=server.serve_forever, daemon=True)
+    loop.start()
+    host, port = server.server_address
+    blocked = threading.Thread(
+        target=lambda: client(host, port, 30).execute_code("while True: pass"),
+        daemon=True,
+    )
+    blocked.start()
+    try:
+        assert interface.entered.wait(5)
+        started = time.monotonic()
+        server.shutdown()
+        loop.join(timeout=5)
+        server.server_close()
+        assert time.monotonic() - started < 2.0
+        assert not loop.is_alive()
+    finally:
+        interface.release.set()
+        blocked.join(timeout=10)


### PR DESCRIPTION
Closes #125

…able

get_rpc_status is documented to report GUI-dispatch health "without using the GUI thread", so that a wedged operation can be identified while it is still wedged. FilteredXMLRPCServer served one request at a time, which defeated that: a blocked execute_code occupied the single accept loop for up to its 90 s timeout, and the status call could not reach the server until the operation it was meant to diagnose had already finished. Mix ThreadingMixIn into FilteredXMLRPCServer so each request is handled in its own thread.
This is safe because every handler that touches FreeCAD funnels through dispatch_to_gui, which owns a queue.Queue of tasks, a private response queue per call, and lock-guarded health state (DispatchHealth). The GUI thread therefore still executes tasks strictly one at a time and in order; only the transport becomes concurrent. Connections are still filtered before a thread is spawned, since verify_request runs in the accept loop ahead of process_request.
daemon_threads must be true: ThreadingMixIn.server_close() joins every non-daemon request thread, so leaving it at the default would make "Stop RPC Server" wait out the very stuck execute_code this change is meant to keep diagnosable.
The comment in stop_rpc_server described the old single-threaded shutdown and is corrected: shutdown() now only stops the accept loop, and in-flight requests are not waited for.
Tests cover the status call arriving during a blocked request, shutdown not waiting for an in-flight request, the daemon_threads invariant, and the IP filter still rejecting before a thread is spawned. All three threading tests fail without the mixin.