### PR TITLE
fix(rpc): keep diagnostics responsive and isolate script state

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ Tools that return a screenshot (`create_object`, `edit_object`, `delete_object`,
 
 If a GUI-thread operation exceeds its timeout after it has started, the bridge
 returns `GUI_DISPATCH_STUCK` and rejects later GUI operations immediately. Use
-`get_rpc_status` to identify the operation that is still running. FreeCAD GUI
+`get_rpc_status` to identify the operation that is still running; the RPC server
+handles each request in its own thread, so that status call is answered even while
+the stuck operation is still holding the GUI thread. FreeCAD GUI
 work cannot be force-cancelled safely; if the status does not return to
 `healthy` after the operation finishes, restart FreeCAD.
 

--- a/README.md
+++ b/README.md
@@ -204,11 +204,18 @@ Tools that return a screenshot (`create_object`, `edit_object`, `delete_object`,
 
 If a GUI-thread operation exceeds its timeout after it has started, the bridge
 returns `GUI_DISPATCH_STUCK` and rejects later GUI operations immediately. Use
-`get_rpc_status` to identify the operation that is still running; the RPC server
-handles each request in its own thread, so that status call is answered even while
-the stuck operation is still holding the GUI thread. FreeCAD GUI
+`get_rpc_status` from a separate RPC client to identify the operation that is
+still running. The RPC server handles connections concurrently, so diagnostics
+do not wait for another request to finish. Document queries (`get_object`,
+`get_objects`, and `list_documents`) run on the GUI thread alongside modelling
+operations and report an RPC fault if dispatch times out or is stuck. FreeCAD GUI
 work cannot be force-cancelled safely; if the status does not return to
 `healthy` after the operation finishes, restart FreeCAD.
+
+`execute_code` and `execute_code_async` share a persistent script namespace with
+`FreeCAD`/`App` and `FreeCADGui`/`Gui` aliases. Script variables survive between
+calls without overwriting the RPC server's own functions. This prevents accidental
+name collisions; code execution still has FreeCAD's full privileges.
 
 After an `execute_code` exception on a FreeCAD development build, inspect any
 new `FeaturePython` object before mutating or deleting it. In particular, do

--- a/addon/FreeCADMCP/rpc_server/ip_filter.py
+++ b/addon/FreeCADMCP/rpc_server/ip_filter.py
@@ -12,8 +12,9 @@ class FilteredXMLRPCServer(ThreadingMixIn, SimpleXMLRPCServer):
     """XML-RPC server that filters connections by allowed IP addresses/subnets.
 
     Threaded so get_rpc_status stays answerable while a wedged GUI task blocks
-    another request; handlers serialise onto the GUI thread through
-    dispatch_to_gui, so concurrency here is safe.
+    another request. Document queries and synchronous modelling handlers
+    serialise onto the GUI thread through dispatch_to_gui. The opt-in
+    execute_code_async worker retains its existing background execution.
 
     daemon_threads must stay true — ThreadingMixIn.server_close() joins
     non-daemon request threads, which would make Stop wait out the stuck

--- a/addon/FreeCADMCP/rpc_server/ip_filter.py
+++ b/addon/FreeCADMCP/rpc_server/ip_filter.py
@@ -2,13 +2,25 @@
 
 import ipaddress
 import re
+from socketserver import ThreadingMixIn
 from xmlrpc.server import SimpleXMLRPCServer
 
 import FreeCAD
 
 
-class FilteredXMLRPCServer(SimpleXMLRPCServer):
-    """XML-RPC server that filters connections by allowed IP addresses/subnets."""
+class FilteredXMLRPCServer(ThreadingMixIn, SimpleXMLRPCServer):
+    """XML-RPC server that filters connections by allowed IP addresses/subnets.
+
+    Threaded so get_rpc_status stays answerable while a wedged GUI task blocks
+    another request; handlers serialise onto the GUI thread through
+    dispatch_to_gui, so concurrency here is safe.
+
+    daemon_threads must stay true — ThreadingMixIn.server_close() joins
+    non-daemon request threads, which would make Stop wait out the stuck
+    operation.
+    """
+
+    daemon_threads = True
 
     def __init__(self, addr, allowed_ips_str="127.0.0.1", **kwargs):
         self._allowed_networks = _parse_allowed_ips(allowed_ips_str)

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -7,7 +7,9 @@ import io
 import os
 import tempfile
 import threading
+from collections.abc import Callable
 from typing import Any
+from xmlrpc.client import Fault
 
 from PySide import QtCore
 
@@ -55,6 +57,18 @@ def _err(res) -> dict:
     if isinstance(res, dict):
         return res
     return {"success": False, "error": str(res)}
+
+
+def _query_on_gui(task: Callable[[], Any], operation: str) -> Any:
+    """Preserve query results while reporting dispatch failures as RPC faults."""
+    # A tuple distinguishes valid results (including None and empty lists)
+    # from the dispatcher's error strings and failure dictionaries.
+    res = dispatch_to_gui(lambda: (task(),), operation_name=operation)
+    if isinstance(res, tuple):
+        return res[0]
+    error = _err(res)
+    code = error.get("code", "GUI_DISPATCH_FAILED")
+    raise Fault(1, f"{code}: {error['error']}")
 
 
 class FreeCADRPC:
@@ -228,7 +242,10 @@ class FreeCADRPC:
         )
         return _err(res)
 
-    def get_objects(self, doc_name):
+    def get_objects(self, doc_name: str) -> list[dict[str, Any]]:
+        return _query_on_gui(lambda: self._get_objects_gui(doc_name), "get_objects")
+
+    def _get_objects_gui(self, doc_name: str) -> list[dict[str, Any]]:
         # FreeCAD.getDocument raises (not returns None) for an unknown name.
         try:
             doc = FreeCAD.getDocument(doc_name)
@@ -236,7 +253,12 @@ class FreeCADRPC:
             return []
         return [serialize_object(obj) for obj in doc.Objects]
 
-    def get_object(self, doc_name, obj_name):
+    def get_object(self, doc_name: str, obj_name: str) -> dict[str, Any] | None:
+        return _query_on_gui(
+            lambda: self._get_object_gui(doc_name, obj_name), "get_object"
+        )
+
+    def _get_object_gui(self, doc_name: str, obj_name: str) -> dict[str, Any] | None:
         # FreeCAD.getDocument raises (not returns None) for an unknown name.
         try:
             doc = FreeCAD.getDocument(doc_name)
@@ -256,8 +278,10 @@ class FreeCADRPC:
             return {"success": True, "message": "Part inserted from library."}
         return _err(res)
 
-    def list_documents(self):
-        return list(FreeCAD.listDocuments().keys())
+    def list_documents(self) -> list[str]:
+        return _query_on_gui(
+            lambda: list(FreeCAD.listDocuments().keys()), "list_documents"
+        )
 
     def get_parts_list(self):
         return get_parts_list()

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -33,6 +33,17 @@ rpc_server_thread = None
 rpc_server_instance = None
 _stop_thread = None  # drains shutdown off the GUI thread; see stop_rpc_server
 
+# Persistent namespace for execute_code / execute_code_async. A dedicated dict
+# (instead of this module's globals()) keeps user code from shadowing server
+# internals like dispatch_to_gui while preserving the documented pattern of
+# sharing module-level variables between successive calls.
+_EXEC_NAMESPACE: dict[str, Any] = {
+    "FreeCAD": FreeCAD,
+    "App": FreeCAD,
+    "FreeCADGui": FreeCADGui,
+    "Gui": FreeCADGui,
+}
+
 
 def _ok(res) -> bool:
     """True when a GUI-thread handler returned success."""
@@ -169,7 +180,7 @@ class FreeCADRPC:
             # GUI thread and other concurrent work. Background code should report
             # via FreeCAD.Console (which is thread-safe) instead.
             try:
-                exec(code, globals())
+                exec(code, _EXEC_NAMESPACE)
                 FreeCAD.Console.PrintMessage("Async code execution completed.\n")
             except Exception as e:
                 import traceback as _tb
@@ -195,7 +206,7 @@ class FreeCADRPC:
 
         def task():
             with contextlib.redirect_stdout(output_buffer):
-                exec(code, globals())
+                exec(code, _EXEC_NAMESPACE)
             return True
 
         res = dispatch_to_gui(

--- a/addon/FreeCADMCP/rpc_server/rpc_server.py
+++ b/addon/FreeCADMCP/rpc_server/rpc_server.py
@@ -424,13 +424,11 @@ def stop_rpc_server():
     cleanup_waker()
 
     def _shutdown_and_close():
-        # shutdown() blocks until serve_forever drains the in-flight request,
-        # and that request may itself be waiting on dispatch_to_gui — running
-        # this on the GUI thread (menu command) froze the UI for up to the
-        # dispatch timeout. server_close() must always follow: without it the
-        # listening socket stays bound and Stop -> Start fails with
-        # EADDRINUSE (the restart the README asks for after changing Remote
-        # Connections or Allowed IPs).
+        # shutdown() only stops the accept loop; in-flight requests run in
+        # their own daemon threads and are not waited for. Kept off the GUI
+        # thread so a menu command cannot block the UI. server_close() must
+        # always follow, or the listening socket stays bound and Stop -> Start
+        # fails with EADDRINUSE.
         try:
             server.shutdown()
             if thread is not None:

--- a/tests/test_rpc_concurrency.py
+++ b/tests/test_rpc_concurrency.py
@@ -1,0 +1,156 @@
+from contextlib import contextmanager
+from pathlib import Path
+from socketserver import ThreadingMixIn
+import sys
+import threading
+import time
+import types
+from typing import Iterator
+import xmlrpc.client
+
+
+ADDON_DIR = Path(__file__).resolve().parents[1] / "addon" / "FreeCADMCP"
+if str(ADDON_DIR) not in sys.path:
+    sys.path.insert(0, str(ADDON_DIR))
+
+
+_filtered_server_class = None
+
+
+def filtered_server_class() -> type:
+    global _filtered_server_class
+    if _filtered_server_class is not None:
+        return _filtered_server_class
+
+    # ip_filter logs rejected connections through FreeCAD.Console and keeps its
+    # own reference after import, so the stub is withdrawn again right away.
+    saved = sys.modules.get("FreeCAD")
+    stub = types.ModuleType("FreeCAD")
+    stub.Console = types.SimpleNamespace(
+        PrintWarning=lambda _message: None, PrintError=lambda _message: None
+    )
+    sys.modules["FreeCAD"] = stub
+    try:
+        sys.modules.pop("rpc_server.ip_filter", None)
+        from rpc_server.ip_filter import FilteredXMLRPCServer
+    finally:
+        if saved is None:
+            sys.modules.pop("FreeCAD", None)
+        else:
+            sys.modules["FreeCAD"] = saved
+
+    _filtered_server_class = FilteredXMLRPCServer
+    return FilteredXMLRPCServer
+
+
+class WedgedGuiThread:
+    def __init__(self) -> None:
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def execute_code(self, code: str) -> dict:
+        self.entered.set()
+        self.release.wait(30)
+        return {"success": True, "message": code}
+
+    def get_rpc_status(self) -> dict:
+        return {
+            "success": True,
+            "rpc_server": "running",
+            "gui_dispatch": {"state": "stuck", "operation": "execute_code"},
+        }
+
+
+class _TimeoutTransport(xmlrpc.client.Transport):
+    def __init__(self, timeout: float):
+        super().__init__()
+        self._timeout = timeout
+
+    def make_connection(self, host):
+        connection = super().make_connection(host)
+        connection.timeout = self._timeout
+        return connection
+
+
+def client(host: str, port: int, timeout: float) -> xmlrpc.client.ServerProxy:
+    return xmlrpc.client.ServerProxy(
+        f"http://{host}:{port}", allow_none=True, transport=_TimeoutTransport(timeout)
+    )
+
+
+def build_server(interface: object):
+    server = filtered_server_class()(
+        ("127.0.0.1", 0), allowed_ips_str="127.0.0.1", allow_none=True, logRequests=False
+    )
+    server.register_instance(interface)
+    return server
+
+
+@contextmanager
+def running_server(interface: object) -> Iterator[tuple[str, int]]:
+    server = build_server(interface)
+    loop = threading.Thread(target=server.serve_forever, daemon=True)
+    loop.start()
+    try:
+        yield server.server_address
+    finally:
+        server.shutdown()
+        loop.join(timeout=5)
+        server.server_close()
+
+
+def test_request_threads_are_daemons_so_stop_does_not_join_them() -> None:
+    server_class = filtered_server_class()
+    assert issubclass(server_class, ThreadingMixIn)
+    assert server_class.daemon_threads is True
+
+
+def test_status_is_answered_while_execute_code_is_blocked() -> None:
+    interface = WedgedGuiThread()
+    with running_server(interface) as (host, port):
+        blocked = threading.Thread(
+            target=lambda: client(host, port, 30).execute_code("while True: pass"),
+            daemon=True,
+        )
+        blocked.start()
+        try:
+            assert interface.entered.wait(5)
+            status = client(host, port, 5).get_rpc_status()
+            assert status["gui_dispatch"]["state"] == "stuck"
+            assert status["gui_dispatch"]["operation"] == "execute_code"
+        finally:
+            interface.release.set()
+            blocked.join(timeout=10)
+
+
+def test_ip_filter_rejects_before_a_thread_is_spawned() -> None:
+    server = build_server(WedgedGuiThread())
+    try:
+        assert server.verify_request(None, ("127.0.0.1", 5000)) is True
+        assert server.verify_request(None, ("10.1.2.3", 5000)) is False
+    finally:
+        server.server_close()
+
+
+def test_stopping_does_not_wait_for_an_in_flight_request() -> None:
+    interface = WedgedGuiThread()
+    server = build_server(interface)
+    loop = threading.Thread(target=server.serve_forever, daemon=True)
+    loop.start()
+    host, port = server.server_address
+    blocked = threading.Thread(
+        target=lambda: client(host, port, 30).execute_code("while True: pass"),
+        daemon=True,
+    )
+    blocked.start()
+    try:
+        assert interface.entered.wait(5)
+        started = time.monotonic()
+        server.shutdown()
+        loop.join(timeout=5)
+        server.server_close()
+        assert time.monotonic() - started < 2.0
+        assert not loop.is_alive()
+    finally:
+        interface.release.set()
+        blocked.join(timeout=10)

--- a/tests/test_rpc_handlers.py
+++ b/tests/test_rpc_handlers.py
@@ -1,0 +1,194 @@
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+import importlib.util
+from pathlib import Path
+import sys
+import threading
+import types
+from xmlrpc.client import Fault
+
+import pytest
+
+from test_gui_dispatch import load_gui_dispatch, ThreadedWaker
+from test_rpc_concurrency import client, running_server
+
+
+RPC_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "addon" / "FreeCADMCP" / "rpc_server" / "rpc_server.py"
+)
+
+
+@pytest.fixture
+def rpc_module(monkeypatch: pytest.MonkeyPatch) -> Iterator[types.ModuleType]:
+    """Exercise real RPC handlers and dispatch with only FreeCAD/Qt stubbed."""
+    with load_gui_dispatch() as dispatch:
+        freecad = dispatch.FreeCAD
+        freecad.Console.PrintMessage = lambda _message: None
+        freecad.Console.PrintWarning = lambda _message: None
+        document = types.SimpleNamespace(
+            Objects=[types.SimpleNamespace(Name="Box")],
+            getObject=lambda name: types.SimpleNamespace(Name=name) if name == "Box" else None,
+        )
+
+        def get_document(name: str) -> object:
+            if name != "Doc":
+                raise NameError(name)
+            return document
+
+        freecad.getDocument = get_document
+        freecad.listDocuments = lambda: {"Doc": document}
+        stubs = {
+            "gui_dispatch": dispatch,
+            "commands": types.SimpleNamespace(
+                register_commands=lambda: None, schedule_toggle_sync=lambda: None
+            ),
+            "fem_executor": types.SimpleNamespace(run_fem_analysis=lambda *_args: None),
+            "object_factory": types.SimpleNamespace(
+                create_object_gui=lambda *_args: None, edit_object_gui=lambda *_args: None
+            ),
+            "property_mapper": types.SimpleNamespace(Object=object),
+            "parts_library": types.SimpleNamespace(
+                get_parts_list=lambda: [], insert_part_from_library=lambda _path: None
+            ),
+            "serialize": types.SimpleNamespace(serialize_object=lambda obj: {"Name": obj.Name}),
+            "settings": types.SimpleNamespace(load_settings=lambda: {}, save_settings=lambda _: None),
+            "view_manager": types.SimpleNamespace(save_active_screenshot=lambda *_args: True),
+        }
+        with monkeypatch.context() as patch:
+            for name, stub in stubs.items():
+                patch.setitem(sys.modules, f"rpc_server.{name}", stub)
+            spec = importlib.util.spec_from_file_location("_rpc_handler_test", RPC_PATH)
+            assert spec is not None and spec.loader is not None
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            waker = ThreadedWaker(dispatch)
+            dispatch._waker = waker
+            module.test_dispatch = dispatch
+            try:
+                yield module
+            finally:
+                waker.join()
+
+
+def test_script_names_cannot_replace_rpc_internals(rpc_module: types.ModuleType) -> None:
+    rpc = rpc_module.FreeCADRPC()
+    original_dispatch = rpc_module.dispatch_to_gui
+    original_serializer = rpc_module.serialize_object
+    result = rpc.execute_code(
+        "dispatch_to_gui = None\nserialize_object = None\n"
+        "FreeCAD = None\nFreeCADGui = None\nshared_value = 41"
+    )
+    assert result["success"] is True
+    assert rpc_module.dispatch_to_gui is original_dispatch
+    assert rpc_module.serialize_object is original_serializer
+    result = rpc.execute_code("print(shared_value + 1)")
+    assert result["success"] is True
+    assert result["message"].endswith("42\n")
+    assert rpc.get_object("Doc", "Box") == {"Name": "Box"}
+
+
+def test_async_scripts_share_variables_without_replacing_dispatch(
+    rpc_module: types.ModuleType,
+) -> None:
+    rpc = rpc_module.FreeCADRPC()
+    original_dispatch = rpc_module.dispatch_to_gui
+    done = threading.Event()
+    rpc_module.FreeCAD.async_done = done
+    assert rpc.execute_code("shared_value = 40")["success"] is True
+    assert rpc.execute_code_async(
+        "dispatch_to_gui = None\nshared_value += 2\nFreeCAD.async_done.set()"
+    )["success"] is True
+    assert done.wait(2)
+    assert rpc_module.dispatch_to_gui is original_dispatch
+    result = rpc.execute_code(
+        "assert App is FreeCAD\nassert Gui is FreeCADGui\nprint(shared_value)"
+    )
+    assert result["success"] is True
+    assert result["message"].endswith("42\n")
+
+
+@pytest.mark.parametrize(
+    ("method", "args", "expected"),
+    [
+        ("list_documents", (), ["Doc"]),
+        ("get_objects", ("Doc",), [{"Name": "Box"}]),
+        ("get_objects", ("Missing",), []),
+        ("get_object", ("Doc", "Box"), {"Name": "Box"}),
+        ("get_object", ("Doc", "Missing"), None),
+        ("get_object", ("Missing", "Box"), None),
+    ],
+)
+def test_queries_use_gui_dispatch_and_keep_response_shapes(
+    rpc_module: types.ModuleType, method: str, args: tuple, expected: object,
+) -> None:
+    dispatched: list[str] = []
+    rpc = rpc_module.FreeCADRPC()
+    original_dispatch = rpc_module.dispatch_to_gui
+
+    def dispatch(task, **kwargs):
+        dispatched.append(kwargs["operation_name"])
+        return original_dispatch(task, **kwargs)
+
+    rpc_module.dispatch_to_gui = dispatch
+    assert getattr(rpc, method)(*args) == expected
+    assert dispatched == [method]
+
+
+@pytest.mark.parametrize(
+    ("method", "args"),
+    [("list_documents", ()), ("get_objects", ("Doc",)), ("get_object", ("Doc", "Box"))],
+)
+def test_queries_fail_without_touching_a_wedged_document(
+    rpc_module: types.ModuleType, method: str, args: tuple,
+) -> None:
+    health = rpc_module.test_dispatch._dispatch_health
+    health.start(100, "execute_code")
+    health.mark_timed_out(100, 90)
+
+    def unexpected_read(*_args):
+        pytest.fail("Document was read while GUI dispatch was stuck")
+
+    rpc_module.FreeCAD.getDocument = unexpected_read
+    rpc_module.FreeCAD.listDocuments = unexpected_read
+    with pytest.raises(Fault, match="GUI_DISPATCH_STUCK.*execute_code"):
+        getattr(rpc_module.FreeCADRPC(), method)(*args)
+
+
+def test_status_and_document_reads_during_real_dispatch(
+    rpc_module: types.ModuleType,
+) -> None:
+    rpc = rpc_module.FreeCADRPC()
+    rpc.EXECUTE_CODE_TIMEOUT = 0.5
+    entered, release, read = threading.Event(), threading.Event(), threading.Event()
+    rpc_module.FreeCAD.test_entered = entered
+    rpc_module.FreeCAD.test_release = release
+    rpc_module.FreeCAD.listDocuments = lambda: (read.set() or {"Doc": object()})
+    with running_server(rpc) as (host, port), ThreadPoolExecutor(max_workers=2) as workers:
+        def request(method: str, *args):
+            with client(host, port, 5) as proxy:
+                return getattr(proxy, method)(*args)
+
+        execution = workers.submit(
+            request, "execute_code",
+            "FreeCAD.test_entered.set()\nFreeCAD.test_release.wait(5)",
+        )
+        try:
+            assert entered.wait(2)
+            status = request("get_rpc_status")
+            assert status["gui_dispatch"]["state"] == "busy"
+            assert status["gui_dispatch"]["operation"] == "execute_code"
+            query = workers.submit(request, "list_documents")
+            # The query must not inspect document state until execution ends.
+            assert not read.wait(0.1)
+            assert execution.result(timeout=2)["code"] == "GUI_DISPATCH_STUCK"
+            assert request("get_rpc_status")["gui_dispatch"]["state"] == "stuck"
+            with pytest.raises(Fault, match="GUI_DISPATCH_STUCK"):
+                request("get_objects", "Doc")
+            release.set()
+            assert query.result(timeout=2) == ["Doc"]
+            assert read.is_set()
+            assert request("get_rpc_status")["gui_dispatch"]["state"] == "healthy"
+            assert request("get_object", "Doc", "Box") == {"Name": "Box"}
+        finally:
+            release.set()


### PR DESCRIPTION
Long-running `execute_code` calls monopolize the XML-RPC accept loop, preventing a second client from calling `get_rpc_status` while the GUI operation is still running. Script assignments also execute in the server module's globals, so a name such as `dispatch_to_gui = None` can disable later RPC calls.

This incorporates the original commits from #126 and #88, preserving their authorship, and completes the concurrency change by dispatching `get_object`, `get_objects`, and `list_documents` onto the GUI thread. These queries currently read live FreeCAD documents directly from the RPC thread; adding request threads without this follow-up permits concurrent document access. Successful query responses, including missing-document `[]`/`None`, remain unchanged. Dispatch failures raise XML-RPC faults containing the diagnostic code. `ping` and `get_rpc_status` remain independent of GUI dispatch.

Both script execution tools share a persistent namespace seeded with `FreeCAD`/`App` and `FreeCADGui`/`Gui`, preserving cross-call variables without replacing RPC internals. Daemon request threads keep server shutdown from waiting for a stuck request.

Validation:

- `uv lock --check`, `uv run python -m compileall src addon`, `uv run pytest -q`: 41 passed.
- Ten selected regression cases fail against pre-fix main `0ff3dd3`, including server-global corruption and document access during stuck dispatch.
- Real TCP tests exercise concurrent status, shutdown, actual RPC handlers and dispatch, deferred document reads, stuck faults, recovery, and sync/async namespace persistence. FreeCAD/Qt are stubbed in these automated tests.
- Live Linux FreeCAD 1.1.1 GUI smoke with dedicated configuration files and a localhost ephemeral port: create a 4 × 3 × 2 box; run a two-second GUI task with a shortened 0.5-second test timeout; observe busy status in about 2 ms, `GUI_DISPATCH_STUCK`, read rejection, recovery, script-name collision resilience, and recovered box volume 24 mm³.
- Wheel/sdist build, CLI help, and `git diff --check` passed.

Diagnostics during an outstanding operation use a separate XML-RPC client connection; this does not change MCP host scheduling. The Windows broken-`FeaturePython` deadlock from #115 has not been reproduced, and running GUI tasks still cannot be force-cancelled. Existing `execute_code_async` background execution remains opt-in.

Fixes #125. Related to #115. Incorporates #126 and #88 with the document-query safety follow-up above.
